### PR TITLE
fix non-spatialized mono

### DIFF
--- a/hxd/snd/Driver.hx
+++ b/hxd/snd/Driver.hx
@@ -119,6 +119,7 @@ class Driver {
 		var bytes = haxe.io.Bytes.alloc(4 * AL_NUM_SOURCES);
 		AL.genSources(AL_NUM_SOURCES, bytes);
 		sources = [for (i in 0...AL_NUM_SOURCES) new Source(ALSource.ofInt(bytes.getInt32(i * 4)))];
+		for (s in sources) AL.sourcei(s.inst, AL.SOURCE_RELATIVE, AL.TRUE);
 
 		cachedBytes = haxe.io.Bytes.alloc(4 * 3 * 2);
 	}
@@ -420,6 +421,10 @@ class Driver {
 			s.playing = false;
 			AL.sourceStop(s.inst);
 		}
+		AL.sourcei(s.inst,  AL.SOURCE_RELATIVE, AL.TRUE);
+		AL.source3f(s.inst, AL.POSITION,  0, 0, 0);
+		AL.source3f(s.inst, AL.VELOCITY,  0, 0, 0);
+		AL.source3f(s.inst, AL.DIRECTION, 0, 0, 0);
 		syncBuffers(s, null);
 	}
 

--- a/hxd/snd/effect/Spatialization.hx
+++ b/hxd/snd/effect/Spatialization.hx
@@ -37,6 +37,8 @@ class Spatialization extends Effect {
 
 	#if hlsdl
 	override function apply(channel : Channel, s : Driver.Source) {
+		AL.sourcei(s.inst,  AL.SOURCE_RELATIVE, AL.FALSE);
+
 		AL.source3f(s.inst, AL.POSITION,  position.x,  position.y,  position.z);
 		AL.source3f(s.inst, AL.VELOCITY,  velocity.x,  velocity.y,  velocity.z);
 		AL.source3f(s.inst, AL.DIRECTION, direction.x, direction.y, direction.z);


### PR DESCRIPTION
Set SOURCE_RELATIVE to true on non-spatialized channels. 
Mono sounds where spatialized even without the Spatialization effect added on the channel.