### PR TITLE
Textinput working on OSX Chrome

### DIFF
--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -78,8 +78,10 @@ class TextInput extends Text {
 
 			var oldIndex = cursorIndex;
 			var oldText = text;
-
 			switch( e.keyCode ) {
+			case K.SHIFT:
+			case K.LEFT_OSX_COMMAND:
+			case K.RIGHT_OSX_COMMAND:
 			case K.LEFT:
 				if( cursorIndex > 0 )
 					cursorIndex--;
@@ -125,11 +127,11 @@ class TextInput extends Text {
 				}
 				return;
 			default:
-				if( e.charCode != 0 && canEdit ) {
+				if( e.keyCode != 0 && canEdit ) {
 					beforeChange();
 					if( selectionRange != null )
 						cutSelection();
-					text = text.substr(0, cursorIndex) + String.fromCharCode(e.charCode) + text.substr(cursorIndex);
+					text = text.substr(0, cursorIndex) + String.fromCharCode(e.keyCode) + text.substr(cursorIndex);
 					cursorIndex++;
 					onChange();
 				}

--- a/hxd/Key.hx
+++ b/hxd/Key.hx
@@ -95,6 +95,9 @@ class Key {
 	public static inline var MOUSE_WHEEL_UP = 2;
 	public static inline var MOUSE_WHEEL_DOWN = 3;
 
+	public static inline var LEFT_OSX_COMMAND = 91;
+	public static inline var RIGHT_OSX_COMMAND = 93;
+
 	/** a bit that is set for left keys **/
 	public static inline var LOC_LEFT = 256;
 	/** a bit that is set for right keys **/


### PR DESCRIPTION
Textinput wasn't working at all on OSX chrome, this fixed it. Also added some keycodes for to prevent fall through character to be added if pressing left or right command button or shift.