### PR TITLE
Take rotation into account for mouseX/Y and event handling in Scene (fixes #51 and #144)

### DIFF
--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -79,11 +79,17 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 	}
 
 	function get_mouseX() {
-		return this.globalToLocal(new Point(stage.mouseX, stage.mouseY)).x;
+		var mx = stage.mouseX - absX;
+		var my = stage.mouseY - absY;
+		var invDet = 1 / (matA * matD - matB * matC);
+		return (mx * matD - my * matC) * invDet;
 	}
 
 	function get_mouseY() {
-		return this.globalToLocal(new Point(stage.mouseX, stage.mouseY)).y;
+		var mx = stage.mouseX - absX;
+		var my = stage.mouseY - absY;
+		var invDet = 1 / (matA * matD - matB * matC);
+		return (-mx * matB + my * matA) * invDet;
 	}
 
 	public function dispatchListeners( event : hxd.Event ) {

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -79,6 +79,9 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 	}
 
 	function get_mouseX() {
+		if (rotation == 0) {
+			return stage.mouseX * width / (stage.width * scaleX) - x;
+		}
 		var mx = stage.mouseX - absX;
 		var my = stage.mouseY - absY;
 		var invDet = 1 / (matA * matD - matB * matC);
@@ -86,6 +89,9 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 	}
 
 	function get_mouseY() {
+		if (rotation == 0) {
+			return stage.mouseY * height / (stage.height * scaleY) - y;
+		}
 		var mx = stage.mouseX - absX;
 		var my = stage.mouseY - absY;
 		var invDet = 1 / (matA * matD - matB * matC);
@@ -141,7 +147,7 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 
 	function screenToLocal( e : hxd.Event ) {
 		var px = e.relX - absX;
-		var py = e.relX - absY;
+		var py = e.relY - absY;
 		var invDet = 1 / (matA * matD - matB * matC);
 		e.relX = (px * matD - py * matC) * invDet;
 		e.relY = ( -px * matB + py * matA) * invDet;

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -165,7 +165,6 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 	}
 
 	public function handleEvent( event : hxd.Event, last : hxd.SceneEvents.Interactive ) : hxd.SceneEvents.Interactive {
-		// var pos = new Point(event.relX, event.relY);
 		var index = last == null ? 0 : interactive.indexOf(cast last) + 1;
 		for( idx in index...interactive.length ) {
 			var i = interactive[idx];

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -1,5 +1,4 @@
 package h2d;
-import h2d.col.Point;
 import hxd.Math;
 
 class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.InteractiveScene {
@@ -175,7 +174,7 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 		var invDet = 1 / (i.matA * i.matD - i.matB * i.matC);
 		var lx = (px * i.matD - py * i.matC) * invDet;
 		var ly = ( -px * i.matB + py * i.matA) * invDet;
-		return new Point(lx, ly);
+		return new h2d.col.Point(lx, ly);
 	}
 
 	public function dispatchEvent( event : hxd.Event, to : hxd.SceneEvents.Interactive ) {

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -79,21 +79,21 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 	}
 
 	function get_mouseX() {
-		if (rotation == 0) {
-			return stage.mouseX * width / (stage.width * scaleX) - x;
-		}
-		var mx = stage.mouseX - absX;
-		var my = stage.mouseY - absY;
+		//if (rotation == 0) {
+			//return stage.mouseX * width / (stage.width * scaleX) - x;
+		//}
+		var mx = stage.mouseX * width / stage.width - absX;
+		var my = stage.mouseY * height / stage.height - absY;
 		var invDet = 1 / (matA * matD - matB * matC);
 		return (mx * matD - my * matC) * invDet;
 	}
 
 	function get_mouseY() {
-		if (rotation == 0) {
-			return stage.mouseY * height / (stage.height * scaleY) - y;
-		}
-		var mx = stage.mouseX - absX;
-		var my = stage.mouseY - absY;
+		//if (rotation == 0) {
+			//return stage.mouseY * height / (stage.height * scaleY) - y;
+		//}
+		var mx = stage.mouseX * width / stage.width - absX;
+		var my = stage.mouseY * height / stage.height - absY;
 		var invDet = 1 / (matA * matD - matB * matC);
 		return (-mx * matB + my * matA) * invDet;
 	}
@@ -146,6 +146,8 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 	}
 
 	function screenToLocal( e : hxd.Event ) {
+		e.relX = e.relX * width / stage.width;
+		e.relY = e.relY * height / stage.height;
 		var px = e.relX - absX;
 		var py = e.relY - absY;
 		var invDet = 1 / (matA * matD - matB * matC);
@@ -164,6 +166,8 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 
 	public function dispatchEvent( event : hxd.Event, to : hxd.SceneEvents.Interactive ) {
 		var i : Interactive = cast to;
+		event.relX = event.relX * width / stage.width;
+		event.relY = event.relY * height / stage.height;
 		var local = interactiveToLocal(i, event.relX, event.relY);
 		event.relX = local.x;
 		event.relY = local.y;
@@ -171,6 +175,8 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 	}
 
 	public function handleEvent( event : hxd.Event, last : hxd.SceneEvents.Interactive ) : hxd.SceneEvents.Interactive {
+		event.relX = event.relX * width / stage.width;
+		event.relY = event.relY * height / stage.height;
 		var index = last == null ? 0 : interactive.indexOf(cast last) + 1;
 		for( idx in index...interactive.length ) {
 			var i = interactive[idx];

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -168,7 +168,7 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 		e.relY = ( -px * matB + py * matA) * invDet;
 	}
 	
-	static function toInteractiveLocal( i : Interactive, x : Float, y : Float ) {
+	static inline function toInteractiveLocal( i : Interactive, x : Float, y : Float ) {
 		var px = x - i.absX;
 		var py = y - i.absY;
 		var invDet = 1 / (i.matA * i.matD - i.matB * i.matC);

--- a/samples/Interactive.hx
+++ b/samples/Interactive.hx
@@ -78,16 +78,18 @@ class Interactive extends hxd.App {
 			initInteract(i, m);
 		}
 
+		s2d.scaleX = 1.2;
+		s2d.rotation = 0.2;
 		b = new h2d.Interactive(150, 100, s2d);
-		b.backgroundColor = 0x80204060;
+		b.backgroundColor = 0xC0204060;
 		b.rotation = Math.PI / 3;
-		//b.scaleX = 1.5; // TODO
+		b.scaleX = 1.5;
 
 		var pix = null;
 		b.onOver = function(e) {
-			var t = h2d.Tile.fromColor(0xFF0000, 3, 3);
-			t.dx = -1;
-			t.dy = -1;
+			var t = h2d.Tile.fromColor(0xFF0000, 5, 5);
+			t.dx = -2;
+			t.dy = -2;
 			pix = new h2d.Bitmap(t, b);
 			pix.x = e.relX;
 			pix.y = e.relY;
@@ -112,6 +114,14 @@ class Interactive extends hxd.App {
 
 	override function update(dt:Float) {
 		obj.rotate(0, 0, 0.002 * dt);
+		
+		var i = s2d.getInteractive(s2d.mouseX, s2d.mouseY);
+		if (i != null) {
+			b.alpha = 0.7;
+		}
+		else {
+			b.alpha = 1.0;
+		}
 	}
 
 

--- a/samples/Interactive.hx
+++ b/samples/Interactive.hx
@@ -1,3 +1,5 @@
+import h2d.Graphics;
+import hxd.Event;
 //PARAM=-D resourcesPath=../../skin_res
 
 class Interactive extends hxd.App {
@@ -78,12 +80,16 @@ class Interactive extends hxd.App {
 			initInteract(i, m);
 		}
 
-		s2d.scaleX = 1.2;
-		s2d.rotation = 0.2;
+		s2d.setPos(10, 10);
+		s2d.scaleY = 1.2;
+		s2d.rotation = 0.3;
+		// s2d.setFixedSize(600, 600);
+
+		
 		b = new h2d.Interactive(150, 100, s2d);
 		b.backgroundColor = 0xC0204060;
 		b.rotation = Math.PI / 3;
-		b.scaleX = 1.5;
+		b.scaleX = 1.2;
 
 		var pix = null;
 		b.onOver = function(e) {
@@ -103,6 +109,22 @@ class Interactive extends hxd.App {
 			pix.remove();
 			pix = null;
 		};
+		b.onClick = function(e) {
+			// Dispatch back a move event. Check that pix doesn't move on click
+			var stage = hxd.Stage.getInstance();
+			e.kind = EMove;
+			e.relX = stage.mouseX;
+			e.relY = stage.mouseY;
+			s2d.dispatchEvent(e, b);
+		}
+		s2d.addEventListener(function (e) {
+			if (e.kind == EPush) {
+				var g  = new Graphics(s2d);
+				g.beginFill(0xff0000);
+				g.drawRect(e.relX, e.relY, 4, 4);
+				g.endFill();
+			}
+		});
 
 		onResize();
 	}
@@ -117,7 +139,7 @@ class Interactive extends hxd.App {
 		
 		var i = s2d.getInteractive(s2d.mouseX, s2d.mouseY);
 		if (i != null) {
-			b.alpha = 0.7;
+			b.alpha = 0.5;
 		}
 		else {
 			b.alpha = 1.0;


### PR DESCRIPTION
Not sure if `globalToLocal` was originally avoided for performance reasons, but this seems to work well.
I've also modified the `Interactive` sample to test combinations of scene rotation and interactive rotation + scaling, as well as testing the `getInteractive` function.