### PR TITLE
Gpu particles tweaks

### DIFF
--- a/h3d/parts/GpuParticles.hx
+++ b/h3d/parts/GpuParticles.hx
@@ -125,10 +125,11 @@ class GpuPartGroup {
 	public var emitAngle(default,set) : Float 	= 1.5;
 	public var emitSync(default, set) : Float	= 0;
 	public var emitDelay(default, set) : Float	= 0;
-
+	public var emitDir(default, set) : h3d.Vector;
 
 	public var clipBounds : Bool				= false;
 	public var transform3D : Bool				= false;
+	public var rotByVelocity : Bool             = false;
 
 	public var size(default, set) : Float		= 1;
 	public var sizeIncr(default, set) : Float	= 0;
@@ -175,6 +176,7 @@ class GpuPartGroup {
 	inline function set_emitAngle(v) { needRebuild = true; return emitAngle = v; }
 	inline function set_emitSync(v) { needRebuild = true; return emitSync = v; }
 	inline function set_emitDelay(v) { needRebuild = true; return emitDelay = v; }
+	inline function set_emitDir(v) { needRebuild = true; return emitDir = v; }
 	inline function set_rotInit(v) { needRebuild = true; return rotInit = v; }
 	inline function set_rotSpeed(v) { needRebuild = true; return rotSpeed = v; }
 	inline function set_rotSpeedRand(v) { needRebuild = true; return rotSpeedRand = v; }
@@ -199,6 +201,7 @@ class GpuPartGroup {
 		pshader.frameDivision.set(frameDivisionX, 1 / frameDivisionX, 1 / frameDivisionY);
 		pshader.clipBounds = emitMode == CameraBounds || clipBounds;
 		pshader.transform3D = transform3D;
+		pshader.rotByVelocity = rotByVelocity;
 		pshader.maxTime = maxTime < 0 ? 1e10 : maxTime;
 	}
 
@@ -370,13 +373,17 @@ class GpuPartGroup {
 			p.y = p.y * ebounds.ySize + c.y;
 			p.z = p.z * ebounds.zSize + c.z;
 
-			v.x = srand();
-			v.y = srand();
-			v.z = srand();
+			if( emitDir == null ) {
+				v.x = srand();
+				v.y = srand();
+				v.z = srand();
+			} else {
+				v.set(emitDir.x, emitDir.y, emitDir.z);
+			}
+
 			v.normalizeFast();
 
 		}
-
 
 		var speed = g.speed * (1 + srand() * g.speedRand);
 
@@ -858,6 +865,7 @@ class GpuParticles extends h3d.scene.MultiMaterial {
 
 		uploadedCount = 0;
 		var hasPart = false;
+		var screenRatio = ctx.engine.height / ctx.engine.width;
 		for( g in groups ) {
 			syncGroup(g, camera, prev, ctx.visibleFlag);
 			if( g.currentParts == 0 )
@@ -866,6 +874,7 @@ class GpuParticles extends h3d.scene.MultiMaterial {
 			hasPart = true;
 			g.syncParams();
 			g.pshader.time = currentTime;
+			g.pshader.screenRatio.set(screenRatio, 1);
 			if( g.pshader.clipBounds ) {
 				g.pshader.volumeMin.set(volumeBounds.xMin, volumeBounds.yMin, volumeBounds.zMin);
 				g.pshader.volumeSize.set(volumeBounds.xSize, volumeBounds.ySize, volumeBounds.zSize);

--- a/h3d/parts/GpuParticles.hx
+++ b/h3d/parts/GpuParticles.hx
@@ -865,7 +865,6 @@ class GpuParticles extends h3d.scene.MultiMaterial {
 
 		uploadedCount = 0;
 		var hasPart = false;
-		var screenRatio = ctx.engine.height / ctx.engine.width;
 		for( g in groups ) {
 			syncGroup(g, camera, prev, ctx.visibleFlag);
 			if( g.currentParts == 0 )
@@ -874,7 +873,6 @@ class GpuParticles extends h3d.scene.MultiMaterial {
 			hasPart = true;
 			g.syncParams();
 			g.pshader.time = currentTime;
-			g.pshader.screenRatio.set(screenRatio, 1);
 			if( g.pshader.clipBounds ) {
 				g.pshader.volumeMin.set(volumeBounds.xMin, volumeBounds.yMin, volumeBounds.zMin);
 				g.pshader.volumeSize.set(volumeBounds.xSize, volumeBounds.ySize, volumeBounds.zSize);

--- a/h3d/shader/GpuParticle.hx
+++ b/h3d/shader/GpuParticle.hx
@@ -41,7 +41,9 @@ class GpuParticle extends hxsl.Shader {
 		@param var offset : Vec3;
 
 		@param var cameraRotation : Mat3;
+		@param var screenRatio : Vec2;
 		@const var transform3D : Bool;
+		@const var rotByVelocity : Bool;
 
 		var t : Float;
 		var normT : Float;
@@ -88,6 +90,14 @@ class GpuParticle extends hxsl.Shader {
 			var current = props.init + props.delta * t;
 			var size = (props.uv - 0.5) * current.y.max(0.);
 			var rot = current.x;
+			if( rotByVelocity ) {
+				var vel = input.normal * (1 + speedIncr * t);
+				vel.z -= gravity * t * t;
+				var dir = (vec4(vel, 0.0) * camera.viewProj).xy / screenRatio;
+				dir = dir.normalize();
+				rot = atan(dir.y, dir.x);
+			}
+
 			var crot = cos(rot), srot = sin(rot);
 			var screenRatio = vec2(global.pixelSize.x / global.pixelSize.y, 1);
 			var dist = vec2(size.x * crot - size.y * srot, size.x * srot + size.y * crot);

--- a/h3d/shader/GpuParticle.hx
+++ b/h3d/shader/GpuParticle.hx
@@ -41,7 +41,6 @@ class GpuParticle extends hxsl.Shader {
 		@param var offset : Vec3;
 
 		@param var cameraRotation : Mat3;
-		@param var screenRatio : Vec2;
 		@const var transform3D : Bool;
 		@const var rotByVelocity : Bool;
 
@@ -90,6 +89,8 @@ class GpuParticle extends hxsl.Shader {
 			var current = props.init + props.delta * t;
 			var size = (props.uv - 0.5) * current.y.max(0.);
 			var rot = current.x;
+
+			var screenRatio = vec2(global.pixelSize.x / global.pixelSize.y, 1);
 			if( rotByVelocity ) {
 				var vel = input.normal * (1 + speedIncr * t);
 				vel.z -= gravity * t * t;
@@ -99,7 +100,6 @@ class GpuParticle extends hxsl.Shader {
 			}
 
 			var crot = cos(rot), srot = sin(rot);
-			var screenRatio = vec2(global.pixelSize.x / global.pixelSize.y, 1);
 			var dist = vec2(size.x * crot - size.y * srot, size.x * srot + size.y * crot);
 			if( transform3D ) {
 				transformedPosition += vec3(0., dist.x, dist.y) * cameraRotation;


### PR DESCRIPTION
- fix rotation on transform3D particle groups

New parameters to help with rain effects :
- **emitDir** : forces emit direction (random if null)
-  **rotByVelocity** : makes the particle point toward its moving direction (rotSpeed disabled)