### PR TITLE
Misc Fixes 

### DIFF
--- a/h2d/CachedBitmap.hx
+++ b/h2d/CachedBitmap.hx
@@ -45,9 +45,11 @@ class CachedBitmap extends Drawable {
 			if( scene == null ) return null;
 			var tw = width < 0 ? scene.width : width;
 			var th = height < 0 ? scene.height : height;
-			var tex = new h3d.mat.Texture(tw, th, [Target]);
-			renderDone = false;
-			tile = Tile.fromTexture(tex);
+			if( tw != 0 && th != 0 ){
+				var tex = new h3d.mat.Texture(tw, th, [Target]);
+				renderDone = false;
+				tile = Tile.fromTexture(tex);
+			}
 		}
 		return tile;
 	}
@@ -60,7 +62,8 @@ class CachedBitmap extends Drawable {
 	}
 
 	override function draw( ctx : RenderContext ) {
-		emitTile(ctx, tile);
+		if( tile != null )
+			emitTile(ctx, tile);
 	}
 
 	override function drawRec( ctx : RenderContext ) {
@@ -68,7 +71,7 @@ class CachedBitmap extends Drawable {
 		if( tile != null && ((width < 0 && scene.width != tile.width) || (height < 0 && scene.height != tile.height)) )
 			clean();
 		var tile = getTile(ctx);
-		if( !freezed || !renderDone ) {
+		if( (!freezed || !renderDone) && tile != null ) {
 			var oldA = matA, oldB = matB, oldC = matC, oldD = matD, oldX = absX, oldY = absY;
 
 			// init matrix without transformation

--- a/h3d/Engine.hx
+++ b/h3d/Engine.hx
@@ -336,6 +336,7 @@ class Engine {
 	 * Call with no parameters to reset to full viewport.
 	 */
 	public function setRenderZone( x = 0, y = 0, ?width = -1, ?height = -1 ) : Void {
+		flushTarget();
 		driver.setRenderZone(x, y, width, height);
 	}
 

--- a/h3d/impl/DirectXDriver.hx
+++ b/h3d/impl/DirectXDriver.hx
@@ -279,7 +279,7 @@ class DirectXDriver extends h3d.impl.Driver {
 	function getTextureFormat( t : h3d.mat.Texture ) : dx.Format {
 		return switch( t.format ) {
 		case RGBA: R8G8B8A8_UNORM;
-		case RGBA16F: R16G16B16A16_UNORM;
+		case RGBA16F: R16G16B16A16_FLOAT;
 		case ALPHA32F: R32_FLOAT;
 		case ALPHA16F: R16_FLOAT;
 		case ALPHA8: R8_UNORM;

--- a/hxd/fs/LocalFileSystem.hx
+++ b/hxd/fs/LocalFileSystem.hx
@@ -322,9 +322,9 @@ class LocalFileSystem implements FileSystem {
 		#end
 		if( exePath != null ) exePath.pop();
 		var froot = exePath == null ? baseDir : sys.FileSystem.fullPath(exePath.join("/") + "/" + baseDir);
-		if( froot == null || !sys.FileSystem.isDirectory(froot) ) {
+		if( froot == null || !sys.FileSystem.exists(froot) || !sys.FileSystem.isDirectory(froot) ) {
 			froot = sys.FileSystem.fullPath(baseDir);
-			if( froot == null || !sys.FileSystem.isDirectory(froot) )
+			if( froot == null || !sys.FileSystem.exists(froot) || !sys.FileSystem.isDirectory(froot) )
 				throw "Could not find dir " + dir;
 		}
 		baseDir = froot.split("\\").join("/");

--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -266,7 +266,7 @@ class HlslOut {
 			case PackNormal:
 				decl("float4 packNormal( float3 n ) { return float4((n + 1.) * 0.5,1.); }");
 			case UnpackNormal:
-				decl("float3 unpackNormal( float4 p ) { return p.xyz * 2. - 1.; }");
+				decl("float3 unpackNormal( float4 p ) { return normalize(p.xyz * 2. - 1.); }");
 			default:
 			}
 			add(GLOBALS.get(g));


### PR DESCRIPTION
- Avoid texture creation in `CachedBitmap` if width or height is zero (fails on DirectX)
- Call flushTarget() before driver.setRenderZone() (`GlDriver` uses `curTarget.height` in setRenderZone)
- Check `FileSystem.exists` before `isDirectory` (isDirectory throws an exception if destination is not accessible)
- Other minor DirectX fixes