### PR TITLE
SmoothStep should be Smoothstep

### DIFF
--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -185,7 +185,7 @@ enum TGlobal {
 	Clamp;
 	Mix;
 	Step;
-	SmoothStep;
+	Smoothstep;
 	Length;
 	Distance;
 	Dot;

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -91,7 +91,7 @@ class Checker {
 						r.push( { args : [ { name : "edge", type : TFloat }, { name : "x", type : t } ], ret : t } );
 				}
 				r;
-			case SmoothStep:
+			case Smoothstep:
 				var r = [];
 				for( t in genType ) {
 					r.push( { args : [ { name : "edge0", type : t }, { name : "edge1", type : t }, { name : "x", type : t } ], ret : t } );


### PR DESCRIPTION
SmoothStep didnt work on JS and HL/DirectX for me.
But works when using **s**tep with lower case.