### PR TITLE
Fixed SDL pad double init

### DIFF
--- a/hxd/Pad.hx
+++ b/hxd/Pad.hx
@@ -350,8 +350,15 @@ class Pad {
 		var p = pads.get( e.controller );
 		switch( e.type ){
 			case GControllerAdded:
-				if( initDone )
+				if( initDone ){
+					if( p != null ){
+						pads.remove( p.index );
+						p.d.close();
+						p.connected = false;
+						p.onDisconnect();
+					}
 					initPad(e.controller);
+				}
 			case GControllerRemoved:
 				if( p != null ){
 					pads.remove( p.index );


### PR DESCRIPTION
On SDL, a pad can be initialized twice (gctrlCount / GControllerAdded event).

The first initialized pad was never correctly closed.