### PR TITLE
Allocation optimizations

### DIFF
--- a/h2d/TileGroup.hx
+++ b/h2d/TileGroup.hx
@@ -368,7 +368,8 @@ private class TileLayerContent extends h3d.prim.Primitive {
 
 	override public function alloc(engine:h3d.Engine) {
 		if( tmp == null ) clear();
-		buffer = h3d.Buffer.ofFloats(tmp, 8, [Quads, RawFormat]);
+		if( tmp.length > 0 )
+			buffer = h3d.Buffer.ofFloats(tmp, 8, [Quads, RawFormat]);
 	}
 
 	public inline function flush() {
@@ -377,7 +378,8 @@ private class TileLayerContent extends h3d.prim.Primitive {
 
 	public function doRender(engine:h3d.Engine, min, len) {
 		flush();
-		engine.renderQuadBuffer(buffer, min, len);
+		if( buffer != null )
+			engine.renderQuadBuffer(buffer, min, len);
 	}
 
 }

--- a/h3d/Engine.hx
+++ b/h3d/Engine.hx
@@ -360,7 +360,7 @@ class Engine {
 	 * Sets up a scissored zone to eliminate pixels outside the given range.
 	 * Call with no parameters to reset to full viewport.
 	 */
-	public function setRenderZone( x = 0, y = 0, ?width = -1, ?height = -1 ) : Void {
+	public function setRenderZone( x = 0, y = 0, width = -1, height = -1 ) : Void {
 		flushTarget();
 		driver.setRenderZone(x, y, width, height);
 	}


### PR DESCRIPTION
- Removed allocations in h2d.RenderContext.pushTarget()
- Re-use `h3d.Buffer` in SpriteBatch (disposed only when the buffer is too small)
- Fixed `h3d.Buffer` creation in TileGroup (when empty)
- Fixed `Null<Int>` alloc for optional args in Engine.setRenderZone()