### PR TITLE
Prevent drawCircle from drawing a triangle when the radius is negative

### DIFF
--- a/h2d/Graphics.hx
+++ b/h2d/Graphics.hx
@@ -422,7 +422,7 @@ class Graphics extends Drawable {
 	public function drawCircle( cx : Float, cy : Float, ray : Float, nsegments = 0 ) {
 		flush();
 		if( nsegments == 0 )
-			nsegments = Math.ceil(ray * 3.14 * 2 / 4);
+			nsegments = Math.ceil(Math.abs(ray * 3.14 * 2 / 4));
 		if( nsegments < 3 ) nsegments = 3;
 		var angle = Math.PI * 2 / nsegments;
 		for( i in 0...nsegments + 1 ) {


### PR DESCRIPTION
When the radius is negative, the drawCircle function will end up drawing a triangle instead of a circle.

Before:
![](https://i.imgur.com/6bFuiSJ.gif)

After:
![](https://i.imgur.com/rXUxGEf.gif)