### PR TITLE
fix TravisCI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,15 @@ haxe:
 matrix:
   allow_failures:
     - haxe: development
-    
+
+install:
+  - yes | haxelib install all
+  - pushd samples
+  - yes | haxelib install all
+  - popd
+  - haxelib dev heaps .
+  - haxelib list
+
 script:
-  - yes | haxelib install all
   - haxe all.hxml
-  - cd samples
-  - yes | haxelib install all
-  - haxe all.hxml
+  - haxe --cwd samples all.hxml


### PR DESCRIPTION
There is `-lib heaps` in all.hxml, so we need to `haxelib dev heaps .` in order to use the current code base instead of using the released version.

There is some other issue with all.hxml, but I will leave it to you to fix. (`hxsl/UniqueChecker.hx:14: characters 17-31 : You cannot access the sys package while targeting js (for sys.FileSystem)`)