### PR TITLE
Added more usesys

### DIFF
--- a/h3d/Engine.hx
+++ b/h3d/Engine.hx
@@ -68,6 +68,8 @@ class Engine {
 		driver = new h3d.impl.Stage3dDriver(antiAlias);
 		#elseif hldx
 		driver = new h3d.impl.DirectXDriver();
+		#elseif usesys
+		driver = new haxe.GraphicsDriver(antiAlias);
 		#else
 		#if sys Sys.println #else trace #end("No output driver available.");
 		driver = new h3d.impl.LogDriver(new h3d.impl.NullDriver());

--- a/h3d/impl/Driver.hx
+++ b/h3d/impl/Driver.hx
@@ -42,6 +42,12 @@ typedef VertexBuffer = { res : dx.Resource, count : Int, stride : Int };
 typedef Texture = { res : dx.Resource, view : dx.Driver.ShaderResourceView, rt : Array<dx.Driver.RenderTargetView>, mips : Int };
 typedef DepthBuffer = { res : dx.Resource, view : dx.Driver.DepthStencilView };
 typedef Query = {};
+#elseif usesys
+typedef IndexBuffer = haxe.GraphicsDriver.IndexBuffer;
+typedef VertexBuffer = haxe.GraphicsDriver.VertexBuffer;
+typedef Texture = haxe.GraphicsDriver.Texture;
+typedef DepthBuffer = haxe.GraphicsDriver.DepthBuffer;
+typedef Query = haxe.GraphicsDriver.Query;
 #else
 typedef IndexBuffer = {};
 typedef VertexBuffer = {};

--- a/h3d/mat/Texture.hx
+++ b/h3d/mat/Texture.hx
@@ -12,6 +12,8 @@ class Texture {
 	public static var nativeFormat(default,never) : TextureFormat =
 		#if flash
 			BGRA
+		#elseif (usesys && !hldx && !hlsdl && !usegl)
+			haxe.GraphicsDriver.nativeFormat
 		#else
 			RGBA // OpenGL, WebGL
 		#end;

--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -53,14 +53,14 @@ class System {
 
 	static function mainLoop() : Bool {
 		// process events
-		#if hldx
+		#if usesys
+		if( !haxe.System.emitEvents(@:privateAccess hxd.Stage.inst.event) )
+			return false;
+		#elseif hldx
 		if( !dx.Loop.processEvents(@:privateAccess hxd.Stage.inst.onEvent) )
 			return false;
 		#elseif hlsdl
 		if( !sdl.Sdl.processEvents(@:privateAccess hxd.Stage.inst.onEvent) )
-			return false;
-		#elseif usesys
-		if( !haxe.System.emitEvents(@:privateAccess hxd.Stage.inst.event) )
 			return false;
 		#end
 


### PR DESCRIPTION
- Uses `haxe.GraphicsDriver` as h3d driver implementation if `usesys` is defined (keep using GlDriver or DirectXDriver if usegl or hldx are defined)
- Always uses `haxe.System.emitEvents` if `usesys` is defined