### PR TITLE
Added hxsl.Cache serialization

### DIFF
--- a/h2d/Drawable.hx
+++ b/h2d/Drawable.hx
@@ -132,7 +132,18 @@ class Drawable extends Sprite {
 
 	public function addShader<T:hxsl.Shader>( s : T ) : T {
 		if( s == null ) throw "Can't add null shader";
-		shaders = new hxsl.ShaderList(s, shaders);
+		var n = new hxsl.ShaderList(s);
+
+		var e = shaders;
+		var p = null;
+		while( e != null && e.s.priority > s.priority ){
+			p = e;
+			e = e.next;
+		}
+		if( p == null ) shaders = n;
+		else p.next = n;
+		n.next = e;
+		
 		return s;
 	}
 

--- a/h3d/impl/DirectXDriver.hx
+++ b/h3d/impl/DirectXDriver.hx
@@ -520,7 +520,7 @@ class DirectXDriver extends h3d.impl.Driver {
 
 	function compileShader( shader : hxsl.RuntimeShader.RuntimeShaderData, compileOnly = false ) {
 		var h = new hxsl.HlslOut();
-		var source = h.run(shader.data);
+		var source = shader.code != null ? shader.code : h.run(shader.data);
 		var bytes = try dx.Driver.compileShader(source, "", "main", (shader.vertex?"vs_":"ps_")+shaderVersion, OptimizationLevel3) catch( err : String ) {
 			err = ~/^\(([0-9]+),([0-9]+)-([0-9]+)\)/gm.map(err, function(r) {
 				var line = Std.parseInt(r.matched(1));

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -223,7 +223,7 @@ class GlDriver extends Driver {
 	function compileShader( glout : ShaderCompiler, shader : hxsl.RuntimeShader.RuntimeShaderData ) {
 		var type = shader.vertex ? GL.VERTEX_SHADER : GL.FRAGMENT_SHADER;
 		var s = gl.createShader(type);
-		var code = glout.run(shader.data);
+		var code = shader.code != null ? shader.code : glout.run(shader.data);
 		gl.shaderSource(s, code);
 		gl.compileShader(s);
 		var log = gl.getShaderInfoLog(s);
@@ -277,7 +277,7 @@ class GlDriver extends Driver {
 				for( v in shader.fragment.data.vars )
 					switch( v.kind ) {
 					case Output:
-						gl.bindFragDataLocation(p.p, outCount++, glout.varNames.get(v.id));
+						gl.bindFragDataLocation(p.p, outCount++, glout.varNames.exists(v.id) ? glout.varNames.get(v.id) : v.name);
 					default:
 					}
 			}
@@ -325,7 +325,7 @@ class GlDriver extends Driver {
 					case TFloat: 1;
 					default: throw "assert " + v.type;
 					}
-					var index = gl.getAttribLocation(p.p, glout.varNames.get(v.id));
+					var index = gl.getAttribLocation(p.p, glout.varNames.exists(v.id) ? glout.varNames.get(v.id) : v.name);
 					if( index < 0 ) {
 						p.stride += size;
 						continue;

--- a/hxsl/Cache.hx
+++ b/hxsl/Cache.hx
@@ -37,10 +37,12 @@ class Cache {
 		if( shader != null )
 			return shader;
 		var s = new hxsl.SharedShader("");
-		var v = vars.copy();
-		var id = haxe.crypto.Md5.encode(vars.join(":")).substr(0, 8);
+		var name = "shaderLinker_"+haxe.crypto.Md5.encode(key).substr(0, 8);
+		#if debug
+		name += '[$key]';
+		#end
 		s.data = {
-			name : "shaderLinker_"+id,
+			name : name,
 			vars : [],
 			funs : [],
 		};

--- a/hxsl/CacheSerializer.hx
+++ b/hxsl/CacheSerializer.hx
@@ -1,0 +1,196 @@
+package hxsl;
+
+import hxsl.RuntimeShader;
+typedef ShaderCompiler = {
+	function run(d : hxsl.Ast.ShaderData) : String;
+	var varNames : Map<Int, String>;
+}
+
+class CacheSerializer extends hxsl.Cache {
+
+	var allInstances : Map<Int, Bool> = new Map();
+	var instancesByShader : Map<String, Array<{id: Int, constBits: Int}>> = new Map();
+
+	var codesMap : Map<String, Int> = new Map();
+	var codes : Array<String> = [];
+
+	var allRuntimes : Map<Int, {vars: Array<hxsl.Output>, runtimes: Array<{ids: Array<Int>, runtime: RuntimeShader, vertex: Int, fragment: Int}>}> = new Map();
+
+	public var glslVersion : Int = 150;
+
+	public function new(){
+		super();
+		@:privateAccess hxsl.Cache.INST = this;
+	}
+
+	override function getLinkShader( vars : Array<hxsl.Output> ){
+		var shader = super.getLinkShader(vars);
+		allRuntimes.set(@:privateAccess shader.instance.id, {vars: vars, runtimes: []});
+		return shader;
+	}
+
+	override function compileRuntimeShader( list : hxsl.ShaderList ){
+		var runtime = super.compileRuntimeShader(list);
+
+		var compiler = initShaderCompiler();
+		var vertexId = genCode(compiler, runtime.vertex, true);
+		var fragmentId = genCode(compiler, runtime.fragment, false);
+
+		var ids = [];
+		for( s in list.next ) @:privateAccess {
+			if( !allInstances.exists(s.instance.id) ){
+				allInstances.set(s.instance.id, true);
+				var c = Type.getClassName(Type.getClass(s));
+				var a = instancesByShader.get(c);
+				if( a == null ) instancesByShader.set(c,a=[]);
+				a.push({id: s.instance.id, constBits: s.constBits});
+			}
+			ids.push(s.instance.id);
+		}
+
+		allRuntimes.get(@:privateAccess list.s.instance.id).runtimes.push({
+			ids: ids,
+			runtime: runtime, 
+			vertex: vertexId, 
+			fragment: fragmentId,
+		});
+
+		return runtime;
+	}
+
+	function genCode( compiler : ShaderCompiler, data : RuntimeShaderData, isVertex : Bool ){
+		var code = compileShader(compiler, data.data, isVertex);
+		data.code = code;
+		
+		var hash = haxe.crypto.Sha1.encode(code);
+		var id = codesMap.get(hash);
+		if( id == null ){
+			id = codes.length;
+			codesMap.set(hash,id);
+			codes.push(code);
+		}
+
+		return id;
+	}
+
+	function initShaderCompiler() : ShaderCompiler {
+		#if usegl
+		return new haxe.GLTypes.ShaderCompiler();
+		#elseif hldx
+		return new hxsl.HlslOut();
+		#else
+		var r = new hxsl.GlslOut();
+		r.version = glslVersion;
+		return r;
+		#end
+	}
+
+	function compileShader( compiler : ShaderCompiler, data : hxsl.Ast.ShaderData, isVertex : Bool ) : String {
+		var code = compiler.run(data);
+
+		#if !hldx
+		for( v in data.vars ){
+			var vname = v.name;
+			if( isVertex && v.kind == Input )
+				vname = compiler.varNames.get(v.id);
+			else if( !isVertex && v.kind == Output )
+				vname = compiler.varNames.get(v.id);
+
+			if( vname != v.name ){
+				trace('Warning: variable name changed from ${v.name} to $vname');
+				v.name = vname;
+			}
+		}
+		#end
+
+		return code;
+	}
+
+	public function serialize(){
+		var ctx = new hxbit.Serializer();
+		ctx.begin();
+
+		// Codes
+		ctx.addInt(codes.length);
+		for( c in codes )
+			ctx.addString(c);
+
+		// Instances
+		ctx.addInt( [for( c in instancesByShader.keys()) c].length );
+		for( c in instancesByShader.keys() ){
+			var a = instancesByShader.get(c);
+			ctx.addString(c);
+			ctx.addInt(a.length);
+			for( o in a){
+				ctx.addInt(o.id);
+				ctx.addInt(o.constBits);
+			}
+		}
+
+		// Shader list
+		var linkIds = [for( c in allRuntimes.keys()) c];
+		ctx.addInt( linkIds.length );
+		for( linkId in linkIds ){
+			var data = allRuntimes.get(linkId);
+			ctx.addString(haxe.Serializer.run(data.vars));
+			ctx.addInt(data.runtimes.length);
+			for( e in data.runtimes ){
+				ctx.addInt(e.ids.length);
+				for( id in e.ids ) 
+					ctx.addInt(id);
+				ctx.addString(serializeRuntime(e.runtime));
+				ctx.addInt(e.vertex);
+				ctx.addInt(e.fragment);
+			}
+		}
+		return haxe.zip.Compress.run(ctx.end(),9);
+	}
+
+	function serializeRuntime( runtime : hxsl.RuntimeShader ){
+		// Note: two runtimes can share id with different variables mapping
+		if( runtime.id >= 0 )
+			runtime.id = -runtime.id - 1;
+		
+		runtime.signature = null;
+		inline function clean(rd:hxsl.RuntimeShader.RuntimeShaderData, isVertex: Bool){
+			rd.data.name = null;
+			rd.data.funs = null;
+			rd.data.vars = rd.data.vars.filter(function(v){
+				v.parent = null;
+				v.qualifiers = null;
+				return v.kind == (isVertex ? Input : Output);
+			});
+			var p = rd.globals;
+			while( p != null ){
+				p.gid = -1;
+				p = p.next;
+			}
+			var p = rd.params;
+			while( p != null ){
+				if( p.perObjectGlobal != null )
+					p.perObjectGlobal.gid = -1;
+				p = p.next;
+			}
+			var p = rd.textures2D;
+			while( p != null ){
+				if( p.perObjectGlobal != null )
+					p.perObjectGlobal.gid = -1;
+				p = p.next;
+			}
+			var p = rd.texturesCube;
+			while( p != null ){
+				if( p.perObjectGlobal != null )
+					p.perObjectGlobal.gid = -1;
+				p = p.next;
+			}
+		}
+		
+		runtime.globals = null;
+		clean(runtime.vertex, true);
+		clean(runtime.fragment, false);
+
+		haxe.Serializer.USE_CACHE = true;
+		return haxe.Serializer.run(runtime);
+	}
+	
+}

--- a/hxsl/CacheUnserializer.hx
+++ b/hxsl/CacheUnserializer.hx
@@ -1,0 +1,128 @@
+package hxsl;
+
+class CacheUnserializer extends hxsl.Cache {
+
+	var allowRuntimeCompilation : Bool;
+	public var shaders : Array<hxsl.RuntimeShader>;
+	var ctx : hxbit.Serializer;
+
+	public function new( bytes : haxe.io.Bytes, allowRuntimeCompilation = true){
+		super();
+		this.allowRuntimeCompilation = allowRuntimeCompilation;
+		@:privateAccess hxsl.Cache.INST = this;
+		unserialize(bytes);
+	}
+
+	function unserialize( bytes : haxe.io.Bytes ){
+		bytes = haxe.zip.Uncompress.run(bytes);
+		ctx = new hxbit.Serializer();
+		ctx.setInput(bytes,0);
+		var ncode = ctx.getInt();
+		var codes = [for( i in 0...ncode ) ctx.getString()];
+		var ninstance = ctx.getInt();
+		var UID = 0;
+		for( i in 0...ninstance ){
+			var c : Dynamic = Type.resolveClass(ctx.getString());
+			if( allowRuntimeCompilation ){
+				var inst : hxsl.Shader = Type.createEmptyInstance(c);
+				@:privateAccess inst.initialize();
+			}
+			var s = c._SHADER;
+			if( s == null ) c._SHADER = s = new hxsl.SharedShader("");
+
+			var nsub = ctx.getInt();
+			for( j in 0...nsub ) @:privateAccess {
+				var id = -ctx.getInt();
+				if( id < UID ) UID = id - 1;
+				var constBits = ctx.getInt();
+
+				if( allowRuntimeCompilation ){
+					var si = s.getInstance(constBits);
+					si.id = id;
+				}else{
+					var si = new hxsl.SharedShader.ShaderInstance(null);
+					si.id = id;
+					s.instanceCache.set(constBits, si);
+				}
+			}
+		}
+
+		var nOutputList = ctx.getInt();
+		shaders = [];
+		if( linkCache.next == null ) 
+			linkCache.next = new Map();
+		for( i in 0...nOutputList ) @:privateAccess { 
+			var outputs = haxe.Unserializer.run(ctx.getString());
+			var linkShader = getLinkShader(outputs);
+			linkShader.instance.id = UID--;
+			var cache = new hxsl.Cache.SearchMap();
+			linkCache.next.set(linkShader.instance.id, cache);
+			var nShaderList = ctx.getInt();
+			for( j in 0...nShaderList ){
+				var n = ctx.getInt();
+				var c = cache;
+				var tmp = [linkShader.instance.id];
+				for( k in 0...n ){
+					var iid = -ctx.getInt();
+					if( c.next == null ) c.next = new Map();
+					var cs = c.next.get(iid);
+					if( cs == null )
+						c.next.set(iid, cs = new hxsl.Cache.SearchMap());
+					c = cs;
+					tmp.push(iid);
+				}
+				c.linked = haxe.Unserializer.run(ctx.getString());
+				c.linked.globals = new Map();
+				reallocGlobals(c.linked, c.linked.vertex);
+				reallocGlobals(c.linked, c.linked.fragment);
+				c.linked.vertex.code = codes[ctx.getInt()];
+				c.linked.fragment.code = codes[ctx.getInt()];
+				shaders.push( c.linked );
+			}
+		}
+		ctx = null;
+	}
+
+	override function compileRuntimeShader( shaders : hxsl.ShaderList ) {
+		onRuntimeCompilation(shaders);
+		if( allowRuntimeCompilation )
+			return super.compileRuntimeShader(shaders);
+		throw "Invalid shaderList";
+		return null;
+	}
+
+	public dynamic function onRuntimeCompilation( shader : hxsl.ShaderList ){
+	}
+
+	static function reallocGlobals(r : hxsl.RuntimeShader, s : hxsl.RuntimeShader.RuntimeShaderData){
+		var p = s.globals;
+		while( p != null ) {
+			if( p.gid < 0 ) p.gid = hxsl.Globals.allocID(p.path);
+			r.globals.set(p.gid, true);
+			p = p.next;
+		}
+		var p = s.params;
+		while( p != null ) {
+			if( p.perObjectGlobal != null ){
+				if( p.perObjectGlobal.gid < 0 ) p.perObjectGlobal.gid = hxsl.Globals.allocID(p.perObjectGlobal.path);
+				r.globals.set(p.perObjectGlobal.gid, true);
+			}
+			p = p.next;
+		}
+		var p = s.textures2D;
+		while( p != null ) {
+			if( p.perObjectGlobal != null ){
+				if( p.perObjectGlobal.gid < 0 ) p.perObjectGlobal.gid = hxsl.Globals.allocID(p.perObjectGlobal.path);
+			}
+			p = p.next;
+		}
+		var p = s.texturesCube;
+		while( p != null ) {
+			if( p.perObjectGlobal != null ){
+				if( p.perObjectGlobal.gid < 0 ) p.perObjectGlobal.gid = hxsl.Globals.allocID(p.perObjectGlobal.path);
+			}
+			p = p.next;
+		}
+	}
+
+}

--- a/hxsl/Eval.hx
+++ b/hxsl/Eval.hx
@@ -15,6 +15,9 @@ class Eval {
 	var constants : Map<Int,TExprDef>;
 	var funMap : Map<TVar,TFunction>;
 	var curFun : TFunction;
+	#if debug
+	var cnames : Array<String> = [];
+	#end
 
 	public function new() {
 		varMap = new Map();
@@ -24,6 +27,13 @@ class Eval {
 
 	public function setConstant( v : TVar, c : Const ) {
 		constants.set(v.id, TConst(c));
+		#if debug
+		cnames.push(v.name+"="+switch(c){
+			case CBool(b): Std.string(b);
+			case CInt(i): Std.string(i);
+			default: "?";
+		});
+		#end
 	}
 
 	function mapVar( v : TVar ) {
@@ -88,8 +98,12 @@ class Eval {
 			curFun = funs[i];
 			curFun.expr = evalExpr(curFun.expr,false);
 		}
+		var name = s.name;
+		#if debug
+		name += "("+cnames.join(",")+")";
+		#end
 		return {
-			name : s.name,
+			name : name,
 			vars : [for( v in s.vars ) mapVar(v)],
 			funs : funs,
 		};

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -604,6 +604,9 @@ class GlslOut {
 
 		decls.push(buf.toString());
 		buf = null;
+
+		s.funs = null;
+		
 		return decls.join("\n");
 	}
 

--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -645,6 +645,9 @@ class HlslOut {
 
 		decls.push(buf.toString());
 		buf = null;
+
+		s.funs = null;
+
 		return decls.join("\n");
 	}
 

--- a/hxsl/Linker.hx
+++ b/hxsl/Linker.hx
@@ -509,7 +509,8 @@ class Linker {
 				allocVar(s.vars[i],null).merged.unshift(sreal.vars[i]);
 		}
 
-		return { name : "out", vars : outVars, funs : funs };
+		var outName = #if debug [for(s in shadersData) s.name].join(" + ") #else "out" #end;
+		return { name : outName, vars : outVars, funs : funs };
 	}
 
 }

--- a/hxsl/RuntimeShader.hx
+++ b/hxsl/RuntimeShader.hx
@@ -34,6 +34,7 @@ class AllocGlobal {
 class RuntimeShaderData {
 	public var vertex : Bool;
 	public var data : Ast.ShaderData;
+	public var code : String;
 	public var params : AllocParam;
 	public var paramsSize : Int;
 	public var globals : AllocGlobal;

--- a/hxsl/SharedShader.hx
+++ b/hxsl/SharedShader.hx
@@ -82,6 +82,9 @@ class SharedShader {
 		eval.unrollLoops = true;
 		#end
 		var i = new ShaderInstance(eval.eval(data));
+		#if !debug
+		i.shader.name += '($constBits)';
+		#end
 		#if debug
 		Printer.check(i.shader, [data]);
 		#end

--- a/hxsl/Splitter.hx
+++ b/hxsl/Splitter.hx
@@ -159,12 +159,12 @@ class Splitter {
 
 		return {
 			vertex : {
-				name : "vertex",
+				name : #if debug s.name+" vertex" #else "vertex" #end,
 				vars : vvars,
 				funs : [vfun],
 			},
 			fragment : {
-				name : "fragment",
+				name : #if debug s.name+" fragment" #else "fragment" #end,
 				vars : fvars,
 				funs : [ffun],
 			},


### PR DESCRIPTION
- Added field `code` in RuntimeShaderData
- Added hxsl.CacheSerializer / hxsl.CacheUnserializer
- Improved shaders names for debug
- ShaderList are now sorted by priority in `h2d.Drawable.addShader()`.
- Don't keep RuntimeShader `funs` AST in memory after code generation