### PR TITLE
JS: Window touch events prevented

### DIFF
--- a/hxd/Stage.js.hx
+++ b/hxd/Stage.js.hx
@@ -26,12 +26,11 @@ class Stage {
 	function new( ?canvas : js.html.CanvasElement ) : Void {
 		eventTargets = new List();
 		resizeEvents = new List();
-
-		element = canvas == null ? js.Browser.window : canvas;
 		if( canvas == null ) {
 			canvas = cast js.Browser.document.getElementById("webgl");
 			if( canvas == null ) throw "Missing canvas #webgl";
 		}
+		element = canvas == null ? js.Browser.window : canvas;		
 		this.canvas = canvas;
 		canvasPos = canvas.getBoundingClientRect();
 		element.addEventListener("mousedown", onMouseDown);


### PR DESCRIPTION
I have a game with a HTML UI layer, and is trying out heaps as renderer, however interactions with the UI layer is blocked on mobile.  Seems like preventDefault is added to all touch actions on the window object, instead of only on the canvas.

EDIT: After looking closer, I cannot really understand why the element should ever be set to window rather than canvas. I can try to refine the PR if I better understood a scenario where one would want to hijack the window events.