### PR TITLE
[js] Implements BytesFileEntry.loadBitmap

### DIFF
--- a/hxd/fs/BytesFileSystem.hx
+++ b/hxd/fs/BytesFileSystem.hx
@@ -1,5 +1,7 @@
 package hxd.fs;
 
+using haxe.io.Path;
+
 class BytesFileEntry extends FileEntry {
 
 	var fullPath : String;
@@ -60,7 +62,15 @@ class BytesFileEntry extends FileEntry {
 		});
 		loader.loadBytes(bytes.getData());
 		#else
-		throw "TODO";
+		var mime = switch fullPath.extension().toLowerCase() {
+			case 'jpg' | 'jpeg': 'image/jpeg';
+			case 'png': 'image/png';
+			case 'gif': 'image/gif';
+			case _: throw 'Cannot determine image encoding, try adding an extension to the resource path';
+		}
+		var img = new js.html.Image();
+		img.onload = function() onLoaded(new hxd.fs.LoadedBitmap(img));
+		img.src = 'data:$mime;base64,' + haxe.crypto.Base64.encode(bytes);
 		#end
 	}
 


### PR DESCRIPTION
Currently it determines the image encoding from the path name.
A better way is to inspect the bytes headers.