### PR TITLE
Allow trailing comma in after a-node

### DIFF
--- a/hxd/fmt/fbx/Parser.hx
+++ b/hxd/fmt/fbx/Parser.hx
@@ -100,6 +100,7 @@ class Parser {
 					}
 				}
 				props.push(floats == null ? PInts(ints) : PFloats(floats));
+				if (peek()==TColon) except(TColon); // Allow trailing ,
 				except(TBraceClose);
 				break;
 			default:


### PR DESCRIPTION
Hi @ncannasse,

I'm trying to import some [Kenney assets](https://kenney.nl/assets/castle-kit), and it was throwing from Parser.hx:

```
/home/jward/tools/haxelib/heaps/1,2,0/hxd/fs/Convert.hx:47: characters 83-88 : Unexpected ',' (} expected) (line 279) in /home/jward/dev/heaps-project/res/Models/towerSquareBaseColor.fbx
```

Looking in his .fbx files, many (all?) have Materials a nodes with **trailing commas**. Here's a screenshot, I included the header with file format info:
![selection_063](https://user-images.githubusercontent.com/2192439/40581319-8332df44-6112-11e8-9f35-4ca6add989c4.png)

Again, I'm not sure if this is right or will have other consequences. But after this fix, heaps began converting these assets correctly:
![image](https://user-images.githubusercontent.com/2192439/40581322-a09bd2f2-6112-11e8-974d-ba793d685563.png)
