### PR TITLE
Bugfix in h3d.pass.Blur

### DIFF
--- a/h3d/pass/Blur.hx
+++ b/h3d/pass/Blur.hx
@@ -100,6 +100,7 @@ class Blur extends ScreenFx<h3d.shader.Blur> {
 		if( (quality <= 0 || passes <= 0 || sigma <= 0) && shader.fixedColor == null ) return;
 
 		if( output == null ) output = src;
+		else h3d.pass.Copy.run(src, output);
 
 		var alloc = tmp == null;
 		if( alloc )
@@ -119,7 +120,7 @@ class Blur extends ScreenFx<h3d.shader.Blur> {
 		output.depthBuffer = null;
 		tmp.depthBuffer = null;
 		for( i in 0...passes ) {
-			shader.texture = src;
+			shader.texture = output;
 			shader.pixel.set(1 / src.width, 0);
 			engine.pushTarget(tmp);
 			render();


### PR DESCRIPTION
In h3d/pass/Blur.hx, if the third parameter (output) of the function apply is not null, every pass would be applied to the src texture, which is not modified : as a result, even if we ask for 5 passes, we'd get the same result as with 1 pass only.

Copying src to output before the loop (should we check for sizes ?) and applying to output should do the trick.