### PR TITLE
Avoid redundant problemMatcher list in tasks.json

### DIFF
--- a/samples/templates/.vscode/tasks.json
+++ b/samples/templates/.vscode/tasks.json
@@ -1,18 +1,10 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=733558
-	// for the documentation about the tasks.json format
 	"version": "2.0.0",
 	"tasks": [
 		{
 			"type": "hxml",
 			"label": "Build",
 			"file": "::name::_hl.hxml",
-			"problemMatcher": [
-				"$haxe-absolute",
-				"$haxe",
-				"$haxe-error",
-				"$haxe-trace"
-			],
 			"presentation": {
 				"reveal": "never"
 			},


### PR DESCRIPTION
I think it's good practice to omit these, even if VSCode generates them automatically. If done so, the defaults from vshaxe's task generation will be used, which means it's more future proof if the list of problem matchers there ever changes. It also makes for a more consise task definition.