### PR TITLE
[WIP] Implement binary FBX support

### DIFF
--- a/hxd/fmt/fbx/BaseLibrary.hx
+++ b/hxd/fmt/fbx/BaseLibrary.hx
@@ -1,4 +1,5 @@
 package hxd.fmt.fbx;
+import haxe.io.Bytes;
 using hxd.fmt.fbx.Data;
 import h3d.col.Point;
 
@@ -148,7 +149,7 @@ class BaseLibrary {
 		defaultModelMatrixes = new Map();
 	}
 
-	public function loadTextFile( data : String ) {
+	public function loadTextFile( data : Bytes ) {
 		load(Parser.parse(data));
 	}
 

--- a/hxd/fmt/fbx/Parser.hx
+++ b/hxd/fmt/fbx/Parser.hx
@@ -160,15 +160,15 @@ class Parser {
 		
 		var props : Array<FbxProp> = new Array();
 		var childs : Array<FbxNode> = new Array();
-		for (i in 0...numProperties) {
+		for ( i in 0...numProperties ) {
 			props.push(readBinaryProperty());
 		}
 		
-		if (pos < nextRecord) {
+		if ( pos < nextRecord ) {
 			do {
 				childs.push(parseBinaryNode());
 			}
-			while (pos + 13 < nextRecord); // There is null-record of 13 bytes afterwards for some reason.
+			while ( pos + 13 < nextRecord ); // There is null-record of 13 bytes afterwards for some reason.
 		}
 		
 		return { name: name, props: props, childs: childs };
@@ -181,13 +181,11 @@ class Parser {
 		var arrayCompressedLen:Int;
 		var arrayBytes:Bytes = null;
 		var arrayBytesPos:Int = 0;
-		inline function readArray(entrySize:Int)
-		{ 
+		inline function readArray(entrySize:Int) {
 			arrayLen = getInt32();
 			arrayEncoding = getInt32();
 			arrayCompressedLen = getInt32();
-			switch(arrayEncoding)
-			{
+			switch( arrayEncoding ) {
 				case 0:
 					arrayBytes = bytes;
 					arrayBytesPos = pos;
@@ -206,7 +204,7 @@ class Parser {
 		// Raw binary data converted to Strings.
 		
 		var type : Int = getByte();
-		switch(type) {
+		switch( type ) {
 			case 'Y'.code:
 				return PInt(getInt16());
 			case 'C'.code:
@@ -224,8 +222,7 @@ class Parser {
 			case 'f'.code:
 				readArray(4);
 				var floats:Array<Float> = new Array();
-				while (arrayLen > 0)
-				{
+				while ( arrayLen > 0 ) {
 					floats.push(arrayBytes.getFloat(arrayBytesPos));
 					arrayBytesPos += 4;
 				}
@@ -233,8 +230,7 @@ class Parser {
 			case 'd'.code:
 				readArray(8);
 				var doubles:Array<Float> = new Array();
-				while (arrayLen > 0)
-				{
+				while ( arrayLen > 0 ) {
 					doubles.push(arrayBytes.getDouble(arrayBytesPos));
 					arrayBytesPos += 8;
 				}
@@ -242,8 +238,7 @@ class Parser {
 			case 'l'.code:
 				readArray(8);
 				var i64s:Array<Int> = new Array();
-				while (arrayLen > 0)
-				{
+				while ( arrayLen > 0 ) {
 					i64s.push(arrayBytes.getInt64(arrayBytesPos).low);
 					arrayBytesPos += 8;
 				}
@@ -251,8 +246,7 @@ class Parser {
 			case 'i'.code:
 				readArray(4);
 				var ints:Array<Int> = new Array();
-				while (arrayLen > 0)
-				{
+				while ( arrayLen > 0 ) {
 					ints.push(arrayBytes.getInt32(arrayBytesPos));
 					arrayBytesPos += 4;
 				}
@@ -260,8 +254,7 @@ class Parser {
 			case 'b'.code:
 				readArray(1);
 				var bools:Array<Int> = new Array();
-				while (arrayLen > 0)
-				{
+				while ( arrayLen > 0 ) {
 					bools.push(arrayBytes.get(arrayBytesPos++));
 				}
 				return PInts(bools);

--- a/hxd/fmt/fbx/Parser.hx
+++ b/hxd/fmt/fbx/Parser.hx
@@ -238,7 +238,6 @@ class Parser {
 		// Raw binary data converted to Strings.
 		
 		var type : Int = getByte();
-		// trace(StringTools.hex(pos), String.fromCharCode(type));
 		switch( type ) {
 			case 'Y'.code:
 				return PInt(getInt16());
@@ -381,11 +380,8 @@ class Parser {
 	}
 	
 	inline function i64ToFloat( i64 : haxe.Int64 ) : Float {
-		// TODO: Find better solution.
 		return (i64.high * 4294967296) + 
 						( (i64.low & 0x80000000) != 0 ? ((i64.low & 0x7fffffff) + 2147483648) : i64.low );
-		// trace(i64, (i64.high * 4294967296) + i64.low, (i64.high * 4294967296) + ((i64.low & 0x7fffffff) + 2147483648));
-		// return Std.parseFloat(Std.string(i64));// (i64.low < 0 ? (-i64.low + 2147483648) : i64.low) + ((i64.high:Float) * 4294967296);
 	}
 	
 	inline function getByte() {

--- a/hxd/fmt/hmd/Dump.hx
+++ b/hxd/fmt/hmd/Dump.hx
@@ -227,7 +227,7 @@ class Dump {
 		var bytes;
 		if( file.split(".").pop().toLowerCase() == "fbx" ) {
 			var l = new hxd.fmt.fbx.HMDOut(file);
-			l.loadTextFile(sys.io.File.getContent(file));
+			l.loadTextFile(sys.io.File.getBytes(file));
 			var hmd = l.toHMD(null, !StringTools.startsWith(file.split("\\").join("/").split("/").pop(), "Anim_"));
 			var out = new haxe.io.BytesOutput();
 			new Writer(out).write(hmd);

--- a/hxd/fs/Convert.hx
+++ b/hxd/fs/Convert.hx
@@ -44,7 +44,7 @@ class ConvertFBX2HMD extends Convert {
 	}
 
 	override function convert() {
-		var fbx = try hxd.fmt.fbx.Parser.parse(srcBytes.toString()) catch( e : Dynamic ) throw Std.string(e) + " in " + srcPath;
+		var fbx = try hxd.fmt.fbx.Parser.parse(srcBytes) catch( e : Dynamic ) throw Std.string(e) + " in " + srcPath;
 		var hmdout = new hxd.fmt.fbx.HMDOut(srcPath);
 		hmdout.load(fbx);
 		var isAnim = StringTools.startsWith(srcFilename, "Anim_") || srcFilename.toLowerCase().indexOf("_anim_") > 0;


### PR DESCRIPTION
Expands FBX parser capabilities to work with binary FBX files.  
There are limitation on properties, which are:
* Int64 properties stored as Floats.
* Raw binary data property read as String.

Both are due to lack of corresponding FbxProp enums.

Information on parsing was based on this article: https://code.blender.org/2013/08/fbx-binary-file-format-specification/