### PR TITLE
Binary FBX 7.5+ support

### DIFF
--- a/hxd/fmt/fbx/Parser.hx
+++ b/hxd/fmt/fbx/Parser.hx
@@ -23,7 +23,8 @@ class Parser {
 	var pos : Int;
 	var token : Null<Token>;
 	var binary : Bool;
-
+	var fbxVersion:Int;
+	
 	function new() {
 	}
 
@@ -49,17 +50,19 @@ class Parser {
 		token = null;
 		if (this.binary) {
 			// Skip header, magic [0x1A, 0x00] and version number.
+			fbxVersion = bytes.getInt32(0x17);
+			
 			this.pos = 21 + 2 + 4;
-			var firstNode = parseBinaryNode(getInt32());
+			var firstNode = parseBinaryNode(getVersionedInt32());
 			if (firstNode.name != "") {
 				
 				// Root was omitted, read until all data obtained.
 				var nodes : Array<FbxNode> = [firstNode];
-				var size:Int = getInt32();
+				var size:Int = getVersionedInt32();
 				
 				while (size != 0) {
 					nodes.push(parseBinaryNode(size));
-					size = getInt32();
+					size = getVersionedInt32();
 				}
 				
 				return {
@@ -171,18 +174,18 @@ class Parser {
 	}
 	
 	function parseBinaryNodes( output : Array<FbxNode> ) {
-		var size : Int = getInt32();
+		var size : Int = getVersionedInt32();
 		while (size != 0)
 		{
 			output.push(parseBinaryNode(size));
-			size = getInt32();
+			size = getVersionedInt32();
 		}
 	}
 	
 	function parseBinaryNode( nextRecord : Int ) : FbxNode {
 		
-		var numProperties : Int = getInt32();
-		var propertyListLength : UInt = getInt32();
+		var numProperties : Int = getVersionedInt32();
+		var propertyListLength : UInt = getVersionedInt32();
 		var nameLen : Int = getByte();
 		var name : String = (nameLen == 0 ? "" : bytes.getString(pos, nameLen));
 		pos += nameLen;
@@ -354,7 +357,14 @@ class Parser {
 	inline function nextChar() {
 		return StringTools.fastCodeAt(buf, pos++);
 	}
-
+	
+	inline function getVersionedInt32() {
+		var i : Int = bytes.getInt32(pos);
+		// No support for file sizes over Int32.
+		pos += fbxVersion >= 7500 ? 8 : 4;
+		return i;
+	}
+	
 	inline function getInt32() {
 		var i : Int = bytes.getInt32(pos);
 		pos += 4;


### PR DESCRIPTION
Or so I thought it will take a rework. In reality 3 fields just became Int64 instead of Int32. This PR does not really introduces proper 7500 FBX support, because I read only low 32 bits, and discard high 32, meaning that files larger than ~2GB cannot be parsed. What a loss :)
I need more FBX7500 files to test thought, because while I managed to parse file posted in #403 [here](https://github.com/HeapsIO/heaps/pull/403#issuecomment-410761180), I could not get it to render (actually even blender couldn't load it). 