### PR TITLE
preventDefault() on wheel events -- keeps page from scrolling

### DIFF
--- a/hxd/Stage.js.hx
+++ b/hxd/Stage.js.hx
@@ -192,6 +192,7 @@ class Stage {
 	}
 
 	function onMouseWheel(e:js.html.WheelEvent) {
+		e.preventDefault();
 		var ev = new Event(EWheel, mouseX, mouseY);
 		ev.wheelDelta = e.deltaY / 120; // browser specific?
 		event(ev);


### PR DESCRIPTION
It's debatable whether you want to _always_ prevent scroll events... But 1) it looks like [touch event defaults are prevented by default](https://github.com/HeapsIO/heaps/blob/master/hxd/Stage.js.hx#L201), and 2) this makes sense for a game engine... so I think preventing wheel events is a good default also. Otherwise, wheel events interact with both the app and the page, which is almost always undesirable -- e.g. try to wheel-zoom in the [world demo](https://heapsio.github.io/heaps.io/samples/world.html):

![scroll](https://user-images.githubusercontent.com/2192439/44314771-9ce0a980-a3d9-11e8-92cb-eef0d179bbd5.gif)
