### PR TITLE
Fix blur filter argument order

### DIFF
--- a/h2d/filter/Blur.hx
+++ b/h2d/filter/Blur.hx
@@ -24,10 +24,10 @@ class Blur extends Filter {
 
 	var pass : h3d.pass.Blur;
 
-	public function new( radius = 1., gain = 1., quality = 1. ) {
+	public function new( radius = 1., gain = 1., quality = 1., linear = 0. ) {
 		super();
 		smooth = true;
-		pass = new h3d.pass.Blur(radius, quality, gain);
+		pass = new h3d.pass.Blur(radius, gain, linear, quality);
 	}
 
 	inline function get_quality() return pass.quality;

--- a/h3d/pass/Blur.hx
+++ b/h3d/pass/Blur.hx
@@ -38,6 +38,7 @@ class Blur extends ScreenFx<h3d.shader.Blur> {
 		this.radius = radius;
 		this.quality = quality;
 		this.gain = gain;
+		this.linear = linear;
 	}
 
 	function set_radius(r) {


### PR DESCRIPTION
Seems like argument order is incorrect when h2d.filter.Blur calls h3d.pass.Blur