### PR TITLE
Filters cut off when using grouped filters with boundsExtend

### DIFF
--- a/h2d/filter/Group.hx
+++ b/h2d/filter/Group.hx
@@ -24,7 +24,9 @@ class Group extends Filter {
 		this.boundsExtend = 0;
 		for( f in filters ) {
 			f.sync(ctx, s);
-			if( f.boundsExtend > boundsExtend ) boundsExtend = f.boundsExtend;
+			if(f.boundsExtend > 0) {
+				boundsExtend += f.boundsExtend;
+			}
 			if( !f.autoBounds ) autoBounds = false;
 		}
 	}


### PR DESCRIPTION
When using multiple filters extending bounds, such as Glow, edges of the filter will be trimmed off. 
Issue seems to be that group boundsExtend are calculated as a max value, but in actuality the bounds will add up.