### PR TITLE
Fix issue with gl shader version being < 100 on IE

### DIFF
--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -630,7 +630,7 @@ class GlslOut {
 		}
 
 		if( isES )
-			decl("#version "+version+(version > 150 ? " es" : ""))
+			decl("#version " + (version < 100 ? 100 : version) + (version > 150 ? " es" : ""));
 		else if( version != null )
 			decl("#version " + (version > 150 ? 150 : version));
 		else


### PR DESCRIPTION
Getting an error with heaps on IE since reported ES version is 0.94, so '#version' in shader is set to 94. However IE expects it to be 100.