### PR TITLE
Add custom cursor support to JS target

### DIFF
--- a/hxd/Cursor.hx
+++ b/hxd/Cursor.hx
@@ -24,6 +24,8 @@ class CustomCursor {
 	static var UID = 0;
 	var name : String;
 	var alloc : flash.ui.MouseCursorData;
+	#elseif js
+	var alloc : Array<String>;
 	#else
 	var alloc : Dynamic;
 	#end
@@ -49,6 +51,8 @@ class CustomCursor {
 			flash.ui.Mouse.unregisterCursor(name);
 			#elseif hldx
 			alloc.destroy();
+			#elseif js
+			// alloc set to null below.
 			#else
 			throw "TODO";
 			#end

--- a/hxd/System.js.hx
+++ b/hxd/System.js.hx
@@ -67,7 +67,17 @@ class System {
 			case Move: "move";
 			case TextInput: "text";
 			case Hide: "none";
-			case Custom(_): throw "Custom cursor not supported";
+			case Custom(cur):
+				if (cur.alloc == null)
+				{
+					if (cur.frames.length > 1) throw "Animated cursor not supported";
+					cur.alloc = new Array();
+					for (frame in cur.frames)
+					{
+						cur.alloc.push("url(\"" + frame.toNative().canvas.toDataURL("image/png") + "\") " + cur.offsetX + " " + cur.offsetY + ", default");
+					}
+				}
+				cur.alloc[0];
 			};
 		}
 	}

--- a/hxd/System.js.hx
+++ b/hxd/System.js.hx
@@ -68,12 +68,10 @@ class System {
 			case TextInput: "text";
 			case Hide: "none";
 			case Custom(cur):
-				if (cur.alloc == null)
-				{
-					if (cur.frames.length > 1) throw "Animated cursor not supported";
+				if ( cur.alloc == null ) {
+					if ( cur.frames.length > 1 ) throw "Animated cursor not supported";
 					cur.alloc = new Array();
-					for (frame in cur.frames)
-					{
+					for ( frame in cur.frames ) {
 						cur.alloc.push("url(\"" + frame.toNative().canvas.toDataURL("image/png") + "\") " + cur.offsetX + " " + cur.offsetY + ", default");
 					}
 				}

--- a/samples/Cursor.hx
+++ b/samples/Cursor.hx
@@ -24,9 +24,6 @@ class Cursor extends hxd.App {
 			i.backgroundColor = Std.random(0x1000000) | 0xFF000000;
 
 			var supported = true;
-			#if js
-			if( c.match(Custom(_)) ) supported = false;
-			#end
 
 			if( !supported ) {
 				tf.textColor = 0xFF0000;


### PR DESCRIPTION
Method of operation:
Uses `url(data: ...)` to set the cursor image. To produce base64 of the bitmap, native `canvas.toDataURL` used instead of Haxe built-in features due to `haxe.zip.Compress` not being implemented on JS.
Animated cursors can be supported by switching the frames, but I'm not sure where the hook for update should be set up. (Same method may also be used to animate cursor on HL target?)