### PR TITLE
Fix audio quality issues on JS target

### DIFF
--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -612,7 +612,11 @@ class Manager {
 		targetFormat   = switch (dat.sampleFormat) {
 			case UI8 : UI8;
 			case I16 : I16;
+			#if js
 			case F32 : F32;
+			#else 
+			case F32 : I16;
+			#end
 		}
 		return targetChannels == dat.channels && targetFormat == dat.sampleFormat && targetRate == dat.samplingRate;
 	}

--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -612,7 +612,7 @@ class Manager {
 		targetFormat   = switch (dat.sampleFormat) {
 			case UI8 : UI8;
 			case I16 : I16;
-			case F32 : I16;
+			case F32 : F32;
 		}
 		return targetChannels == dat.channels && targetFormat == dat.sampleFormat && targetRate == dat.samplingRate;
 	}

--- a/hxd/snd/openal/Driver.hx
+++ b/hxd/snd/openal/Driver.hx
@@ -115,7 +115,11 @@ class Driver implements hxd.snd.Driver {
 		var alFormat = switch (format) {
 			case UI8 : channelCount == 1 ? AL.FORMAT_MONO8  : AL.FORMAT_STEREO8;
 			case I16 : channelCount == 1 ? AL.FORMAT_MONO16 : AL.FORMAT_STEREO16;
+			#if (js)
 			case F32 : channelCount == 1 ? AL.FORMAT_MONOF32 : AL.FORMAT_STEREOF32;
+			#else
+			case F32 : channelCount == 1 ? AL.FORMAT_MONO16 : AL.FORMAT_STEREO16;
+			#end
 		}
 		AL.bufferData(buffer.inst, alFormat, data, size, samplingRate);
 	}

--- a/hxd/snd/openal/Driver.hx
+++ b/hxd/snd/openal/Driver.hx
@@ -115,7 +115,7 @@ class Driver implements hxd.snd.Driver {
 		var alFormat = switch (format) {
 			case UI8 : channelCount == 1 ? AL.FORMAT_MONO8  : AL.FORMAT_STEREO8;
 			case I16 : channelCount == 1 ? AL.FORMAT_MONO16 : AL.FORMAT_STEREO16;
-			case F32 : channelCount == 1 ? AL.FORMAT_MONO16 : AL.FORMAT_STEREO16;
+			case F32 : channelCount == 1 ? AL.FORMAT_MONOF32 : AL.FORMAT_STEREOF32;
 		}
 		AL.bufferData(buffer.inst, alFormat, data, size, samplingRate);
 	}


### PR DESCRIPTION
Poor audio quality on JS was caused by resampling of F32 data to I16, resulting in extreme precision loss.
It's a partial fix of #431, but response time and early cut issues still present.