### PR TITLE
Add workaround to chromium memory leak for js audio.

### DIFF
--- a/hxd/snd/NativeChannel.hx
+++ b/hxd/snd/NativeChannel.hx
@@ -105,6 +105,10 @@ class NativeChannel {
 		}
 		return ctx;
 	}
+	// Pool implemented to workaround memory leak in chromium browsers:
+	// https://bugs.chromium.org/p/chromium/issues/detail?id=379753
+	static var pool : Map<Int, Array<js.html.audio.ScriptProcessorNode>> = new Map();
+	
 	var sproc : js.html.audio.ScriptProcessorNode;
 	var tmpBuffer : haxe.io.Float32Array;
 	#elseif lime_openal
@@ -121,7 +125,12 @@ class NativeChannel {
 		#elseif js
 		var ctx = getContext();
 		if( ctx == null ) return;
-		sproc = ctx.createScriptProcessor(bufferSamples, 2, 2);
+		var sprocPool = pool.get(bufferSamples);
+		if ( sprocPool != null && sprocPool.length > 0 ) {
+			sproc = sprocPool.pop();
+		} else {
+			sproc = ctx.createScriptProcessor(bufferSamples, 2, 2);
+		}
 		tmpBuffer = new haxe.io.Float32Array(bufferSamples * 2);
 		sproc.connect(ctx.destination);
 		sproc.onaudioprocess = onJsSample;
@@ -190,6 +199,13 @@ class NativeChannel {
 		}
 		#elseif js
 		if( sproc != null ) {
+			var sprocPool = pool.get(bufferSamples);
+			if (sprocPool == null) {
+				sprocPool = [sproc];
+				pool.set(bufferSamples, sprocPool);
+			} else {
+				sprocPool.push(sproc);
+			}
 			sproc.disconnect();
 			sproc = null;
 		}


### PR DESCRIPTION
Adds pooling of created ScriptProcessorNodes, to avoid memory leaks. As in chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=379753
Reported by @lbergman here: https://github.com/HeapsIO/heaps/issues/431#issuecomment-425915172