### PR TITLE
Rework JS NativeChannel

### DIFF
--- a/hxd/snd/NativeChannel.hx
+++ b/hxd/snd/NativeChannel.hx
@@ -94,7 +94,11 @@ class NativeChannel {
 			try {
 				ctx = new js.html.audio.AudioContext();
 			} catch( e : Dynamic ) try {
+				#if (haxe_ver >= 4)
+				ctx = js.Syntax.code('new window.webkitAudioContext()');
+				#else
 				ctx = untyped __js__('new window.webkitAudioContext()');
+				#end
 			} catch( e : Dynamic ) {
 				ctx = null;
 			}

--- a/hxd/snd/NativeChannel.hx
+++ b/hxd/snd/NativeChannel.hx
@@ -239,11 +239,12 @@ class NativeChannel {
 		}
 		#elseif js
 		if ( front != null ) {
-			current.stop();
+			current.disconnect();
 			current.removeEventListener("ended", swap);
 			current = null;
 			
 			queued.removeEventListener("ended", swap);
+			queued.disconnect();
 			queued.stop();
 			queued = null;
 			

--- a/hxd/snd/openal/Emulator.hx
+++ b/hxd/snd/openal/Emulator.hx
@@ -78,7 +78,7 @@ class Source {
 	// This seems related to some lag in NativeChannel creation and data delivery
 	static inline var STOP_DELAY = #if js 200 #else 0 #end;
 
-	public static var CHANNEL_BUFSIZE = 4096; /* 100 ms latency @44.1Khz */
+	public static var CHANNEL_BUFSIZE = #if js 8192 #else 4096 #end; // 4096; /* 100 ms latency @44.1Khz */
 
 	static var ID = 0;
 	static var all = new Map<Int,Source>();

--- a/hxd/snd/openal/Emulator.hx
+++ b/hxd/snd/openal/Emulator.hx
@@ -78,7 +78,7 @@ class Source {
 	// This seems related to some lag in NativeChannel creation and data delivery
 	static inline var STOP_DELAY = #if js 200 #else 0 #end;
 
-	public static var CHANNEL_BUFSIZE = #if js 8192 #else 4096 #end; // 4096; /* 100 ms latency @44.1Khz */
+	public static var CHANNEL_BUFSIZE = #if js 8192 #else 4096 #end; /* 100 ms latency @44.1Khz */
 
 	static var ID = 0;
 	static var all = new Map<Int,Source>();


### PR DESCRIPTION
Okay, this is quite large internal change. Primary reason to such drastic change - poor browser support of ScriptProcessorNode. (Memory leaks, asynchronous method of operation, latency, etc. Also it's deprecated in favor of AudioWorklets).
Current approach pretty much uses same method as ScriptProcessorNode, but instead relies on `AudioBuffer` and `AudioBufferSource` for playback, which are a lot more stable.
Implementation notes:
* `time` variable is mandatory to sync back-to-back buffer playback, otherwise they will have an audible gaps due to `ended` event being asynchronous, and `AudioContext.currentTime` being slightly ahead in time.
* It always fills both buffers at start (bufferSamples*2), I'm not sure how that'll work out for extremely short sounds that fit in just one buffer.
* Channel buffer size increased to 8192 to fix sound distortion in Firefox. It does not introduce more latency, as it is no longer affects it due to data being buffered ahead of time.

This resolves next issues:
* Enormous sound latency on Chrome.
* Large sound distortion when multiple sounds played at once. No idea why ScriptProcessor had that issue, but BufferSource doesn't.

Unresolved issues:
- [x] [Firefox] Some sounds still have glitching. See this [image](https://i.imgur.com/MvlxMKg.png) for reference. To the left is firefox (central part have "glitch"), to the right is the correct waveform, produced by Chrome. Note: Distortion appears on 4096 buffer size, disappears on 8192 size and sound straight out broken on 2048.
- [ ] [Firefox] Looping of sounds have noticeably more distortion if the loop isn't perfect. -- Wontfix
- [x] Not sure if I have to pool created AudioBuffers. Avoids excessive allocs, but is really necessary?
- [x] When playing multiple sounds, it does not distort them it was before, but it now cuts some sounds early, seems like previous sound playback stops current sound playback for some reason. 
- [ ] When tab is not active, sound playback will stop. On chrome it just cuts, but on firefox for some reason it sometimes plays some buffers occasionally.

It should fix #431 latency and multiple sounds issue. 