### PR TITLE
Update variable names for XHR progress event with compat.

### DIFF
--- a/hxd/net/BinaryLoader.hx
+++ b/hxd/net/BinaryLoader.hx
@@ -46,7 +46,13 @@ class BinaryLoader {
 			onLoaded(haxe.io.Bytes.ofData(xhr.response));
 		}
 		
-		xhr.onprogress = function(e) onProgress(Std.int(e.position), Std.int(e.totalSize));
+		xhr.onprogress = function(e) {
+			#if (haxe_ver >= 4)
+			onProgress(Std.int(js.Syntax.code("e.loaded || e.position")), Std.int(js.Syntax.code("e.total || e.totalSize")));
+			#else
+			onProgress(Std.int(untyped __js__("e.loaded || e.position")), Std.int(untyped __js__("e.total || e.totalSize")));
+			#end
+		}
 		xhr.send();
 		#end
 	}

--- a/hxd/net/BinaryLoader.hx
+++ b/hxd/net/BinaryLoader.hx
@@ -48,9 +48,9 @@ class BinaryLoader {
 		
 		xhr.onprogress = function(e) {
 			#if (haxe_ver >= 4)
-			onProgress(Std.int(js.Syntax.code("e.loaded || e.position")), Std.int(js.Syntax.code("e.total || e.totalSize")));
+			onProgress(Std.int(js.Syntax.code("{0}.loaded || {0}.position", e)), Std.int(js.Syntax.code("{0}.total || {0}.totalSize", e)));
 			#else
-			onProgress(Std.int(untyped __js__("e.loaded || e.position")), Std.int(untyped __js__("e.total || e.totalSize")));
+			onProgress(Std.int(untyped __js__("{0}.loaded || {0}.position", e)), Std.int(untyped __js__("{0}.total || {0}.totalSize", e)));
 			#end
 		}
 		xhr.send();


### PR DESCRIPTION
Modern standard uses `loaded` and `total` variables instead of `position` / `totalSize`. Fixed `BinaryLoader` to use proper variable names, but kept the compatibility with older ones. 
Btw does it even have to keep comparability? Old variable names are quite outdated and Heaps utilizes pretty modern APIs in general.