### PR TITLE
Add support for non-relative 2D particles

### DIFF
--- a/h2d/Particles.hx
+++ b/h2d/Particles.hx
@@ -364,11 +364,20 @@ class ParticleGroup {
 			// called during sync() call which calls this function if required before any of this happens.
 			//parts.syncPos();
 
-			p.x = p.x * parts.matA + p.y * parts.matC + parts.absX;
-			p.y = p.x * parts.matB + p.y * parts.matD + parts.absY;
+			var px = p.x;
+			p.x = px * parts.matA + p.y * parts.matC + parts.absX;
+			p.y = px * parts.matB + p.y * parts.matD + parts.absY;
 			p.scaleX = Math.sqrt((parts.matA * parts.matA) + (parts.matC * parts.matC)) * size;
 			p.scaleY = Math.sqrt((parts.matB * parts.matB) + (parts.matD * parts.matD)) * size;
-			p.rotation += Math.acos(parts.matA / p.scaleX);
+			var rot = Math.atan2(parts.matB / p.scaleY, parts.matA / p.scaleX);
+			p.rotation += rot;
+			
+			// Also rotate velocity.
+			var cos = Math.cos(rot);
+			var sin = Math.sin(rot);
+			px = p.vx;
+			p.vx = px * cos - p.vy * sin;
+			p.vy = px * sin + p.vy * cos;
 		}
 
 	}

--- a/h2d/Particles.hx
+++ b/h2d/Particles.hx
@@ -497,8 +497,8 @@ class Particles extends Drawable {
 					matB = 0;
 					matC = 0;
 					matD = 1;
-					absX = this.x;
-					absY = this.y;
+					absX = 0;
+					absY = 0;
 					g.batch.drawWith(ctx, this);
 					matA = realA;
 					matB = realB;

--- a/h2d/Particles.hx
+++ b/h2d/Particles.hx
@@ -364,8 +364,8 @@ class ParticleGroup {
 			// called during sync() call which calls this function if required before any of this happens.
 			//parts.syncPos();
 
-			p.x += p.x * parts.matA + p.y * parts.matC + parts.absX;
-			p.y += p.x * parts.matB + p.y * parts.matD + parts.absY;
+			p.x = p.x * parts.matA + p.y * parts.matC + parts.absX;
+			p.y = p.x * parts.matB + p.y * parts.matD + parts.absY;
 			p.scaleX = Math.sqrt((parts.matA * parts.matA) + (parts.matC * parts.matC)) * size;
 			p.scaleY = Math.sqrt((parts.matB * parts.matB) + (parts.matD * parts.matD)) * size;
 			p.rotation += Math.acos(parts.matA / p.scaleX);


### PR DESCRIPTION
Feature requested in [this topic](https://community.heaps.io/t/make-particles-position-not-relative-to-its-parent/39).
Adds support to make particles non-relative.
Implementation details:
I apply position difference between initial global position of particle and new global position of particles objects. Calculations are done once per particle init and once per frame per group (multiple particle groups would invoke `Object.localToGlobal` multiple times and initialization of object would call it `nparts` time per group).
There also an issue with some particles "twitching" while in this mode, most likely due to conversion local->global->local->global and I'm not sure if I'll be able to solve this issue.