### PR TITLE
Text: Initialize glyphs if they weren't on draw call.

### DIFF
--- a/h2d/Text.hx
+++ b/h2d/Text.hx
@@ -100,6 +100,8 @@ class Text extends Drawable {
 			emitTile(ctx, h2d.Tile.fromColor(0xFF00FF, 16, 16));
 			return;
 		}
+		if ( !calcDone ) initGlyphs(text, false);
+
 		if( dropShadow != null ) {
 			var oldX = absX, oldY = absY;
 			absX += dropShadow.dx * matA + dropShadow.dy * matC;


### PR DESCRIPTION
`rebuild()` checks if Text was added to Scene properly, which prevents it from initializing glyph data, and, in turn, disabled ability to render text onto texture without adding it to into scene chain.  Fix now checks for `calcDone` on draw call and initializes glyphs if it wasn't done yet.
Fix #358 