### PR TITLE
Basic video support on JS target.

### DIFF
--- a/h2d/Video.hx
+++ b/h2d/Video.hx
@@ -149,7 +149,11 @@ class Video extends Drawable {
 	#if js
 	
 	function errorHandler(e : js.html.Event) {
+		#if (haxe_ver >= 4)
 		onError(v.error.code + ": " + v.error.message);
+		#else 
+		onError(Std.string(v.error.code));
+		#end
 	}
 	
 	function endHandler(e : js.html.Event) {

--- a/h2d/Video.hx
+++ b/h2d/Video.hx
@@ -176,7 +176,7 @@ class Video extends Drawable {
 			#elseif js
 			texture.alloc();
 			texture.checkSize(videoWidth, videoHeight, 0);
-			cast (@:privateAccess texture.mem.driver, h3d.impl.GlDriver).uploadTextureVideoElement(texture, v, 0, 0);
+			@:privateAccess cast (@:privateAccess texture.mem.driver, h3d.impl.GlDriver).uploadTextureVideoElement(texture, v, 0, 0);
 			texture.flags.set(WasCleared);
 			texture.checkMipMapGen(0, 0);
 			#end

--- a/h2d/Video.hx
+++ b/h2d/Video.hx
@@ -28,12 +28,12 @@ class Video extends Drawable {
 	#if hl
 	static var INIT_DONE = false;
 	var v : VideoImpl;
+	var pixels : hxd.Pixels;
 	#elseif js
 	var v : js.html.VideoElement;
 	var videoPlaying : Bool;
 	var videoTimeupdate : Bool;
 	var onReady : Void->Void;
-	var pixels : hxd.Pixels;
 	#end
 	var texture : h3d.mat.Texture;
 	var tile : h2d.Tile;

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -1534,7 +1534,7 @@ class GlDriver extends Driver {
 	}
 	
 	// Draws video element directly onto Texture. Used for video rendering.
-	public function uploadTextureVideoElement( t : h3d.mat.Texture, v : js.html.VideoElement, mipLevel : Int, side : Int ) {
+	private function uploadTextureVideoElement( t : h3d.mat.Texture, v : js.html.VideoElement, mipLevel : Int, side : Int ) {
 		var cubic = t.flags.has(Cube);
 		var bind = getBindType(t);
 		if( t.flags.has(IsArray) ) throw "TODO:texImage3D";

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -1532,6 +1532,23 @@ class GlDriver extends Driver {
 			false;
 		}
 	}
+	
+	// Draws video element directly onto Texture. Used for video rendering.
+	public function uploadTextureVideoElement( t : h3d.mat.Texture, v : js.html.VideoElement, mipLevel : Int, side : Int ) {
+		var cubic = t.flags.has(Cube);
+		var bind = getBindType(t);
+		if( t.flags.has(IsArray) ) throw "TODO:texImage3D";
+		var face = cubic ? CUBE_FACES[side] : GL.TEXTURE_2D;
+		gl.bindTexture(bind, t.t.t);
+		if (glES >= 3) {
+			// WebGL2 support
+			gl.texImage2D(face, mipLevel, t.t.internalFmt, v.videoWidth, v.videoHeight, 0, getChannels(t.t), t.t.pixelFmt, untyped v);
+		} else {
+			gl.texImage2D(face, mipLevel, t.t.internalFmt, t.t.internalFmt, t.t.pixelFmt, v);
+		}
+		restoreBind();
+	}
+	
 	#end
 
 	override function captureRenderBuffer( pixels : hxd.Pixels ) {

--- a/samples/Video.hx
+++ b/samples/Video.hx
@@ -12,7 +12,11 @@ class Video extends hxd.App {
 			tf.textColor = 0xFF0000;
 		};
 		function start() {
+			#if hl
 			video.load("testVideo.avi");
+			#elseif js
+			video.load("testVideo.mp4");
+			#end
 		}
 		video.onEnd = start;
 		start();


### PR DESCRIPTION
Provides basic implementation of h2d.Video on JS target.
Tested on WebGL2 compatible browsers and abomination that shouldn't have seen light of day - Edge (WebGL1).
What's lacking:
* ~Video is set on loop, it never actually invokes `onEnd`~
* Video should be provided as an url and cannot be bundled as part of embedded or pak resources.
* ~There is no error handling (e.g. if video loading fails)~
* Adds out-of-spec function to `GlDriver` on JS target to allow rendering of the video element onto texture.
* No audio output provided.

Overall this implementation feels a bit hacky for me personally, so I'd be glad to receive some feedback. Especially if some of the provided above points should be fixed before merge. 

Fix #444 