### PR TITLE
FBX: Save all animations to HMD.

### DIFF
--- a/hxd/fmt/fbx/BaseLibrary.hx
+++ b/hxd/fmt/fbx/BaseLibrary.hx
@@ -730,6 +730,17 @@ class BaseLibrary {
 		return hasValue;
 	}
 
+	/**
+		Returns an array of names with all animations present in FBX file.
+	**/
+	public function getAnimationNames() : Array<String> {
+		var names = [];
+		for ( a in this.root.getAll("Objects.AnimationStack") ) {
+			names.push(a.getName());
+		}
+		return names;
+	}
+
 	public function loadAnimation( ?animName : String, ?root : FbxNode, ?lib : BaseLibrary ) : h3d.anim.Animation {
 		if( lib != null ) {
 			lib.defaultModelMatrixes = defaultModelMatrixes;

--- a/hxd/fmt/fbx/HMDOut.hx
+++ b/hxd/fmt/fbx/HMDOut.hx
@@ -805,9 +805,11 @@ class HMDOut extends BaseLibrary {
 
 		addModels(includeGeometry);
 
-		var anim = loadAnimation();
-		if( anim != null )
+		var names = getAnimationNames();
+		for ( animName in names ) {
+			var anim = loadAnimation(animName);
 			d.animations.push(makeAnimation(anim));
+		}
 
 		d.data = dataOut.getBytes();
 		return d;


### PR DESCRIPTION
For some reason FBX->HMD converter tried to read only one animation from FBX. This change forces it to save all animation stacks present in the FBX. 