### PR TITLE
Fix runtime JS parsing crash on invalid codepoint on Raw binary property

### DIFF
--- a/hxd/fmt/fbx/Data.hx
+++ b/hxd/fmt/fbx/Data.hx
@@ -7,6 +7,7 @@ enum FbxProp {
 	PIdent( i : String );
 	PInts( v : Array<Int> );
 	PFloats( v : Array<Float> );
+	PBinary( v : haxe.io.Bytes );
 }
 
 typedef FbxNode = {
@@ -124,6 +125,14 @@ class FbxTools {
 		if( n == null ) throw "null prop";
 		return switch( n ) {
 		case PString(v): v;
+		default: throw "Invalid prop " + n;
+		}
+	}
+
+	public static function toBinary( n : FbxProp ) {
+		if ( n == null ) throw "null prop";
+		return switch( n ) {
+		case PBinary(v): v;
 		default: throw "Invalid prop " + n;
 		}
 	}

--- a/hxd/fmt/fbx/Parser.hx
+++ b/hxd/fmt/fbx/Parser.hx
@@ -300,11 +300,19 @@ class Parser {
 					arrayLen--;
 				}
 				return PInts(bools);
-			case 'S'.code, 'R'.code:
+			case 'S'.code:
 				var len:Int = getInt32();
 				var s:String = bytes.getString(pos, len);
 				pos += len;
 				return PString(s);
+			case 'R'.code:
+				var len:Int = getInt32();
+				// Nothing uses this apart from occasional metadata, make an issue if for some reason
+				// you need to parse those properties.
+				// Disabled handling as PString due to JS target being angry on wrong codepoints.
+				trace("FBX parser warning: Skipped Raw binary data for binary property! At position: " + pos + ", size: " + len);
+				pos += len;
+				return PString("");
 			default:
 				return error("Unknown property type: " + type + "/" + String.fromCharCode(type));
 		}

--- a/hxd/fmt/fbx/Parser.hx
+++ b/hxd/fmt/fbx/Parser.hx
@@ -307,12 +307,10 @@ class Parser {
 				return PString(s);
 			case 'R'.code:
 				var len:Int = getInt32();
-				// Nothing uses this apart from occasional metadata, make an issue if for some reason
-				// you need to parse those properties.
-				// Disabled handling as PString due to JS target being angry on wrong codepoints.
-				trace("FBX parser warning: Skipped Raw binary data for binary property! At position: " + pos + ", size: " + len);
+				var data = Bytes.alloc(len);
+				data.blit(0, bytes, pos, len);
 				pos += len;
-				return PString("");
+				return PBinary(data);
 			default:
 				return error("Unknown property type: " + type + "/" + String.fromCharCode(type));
 		}


### PR DESCRIPTION
Bug was caused due to JS specifics and `readString` tried to read it into cohesive valid String. I disabled handling of `R` property type (Raw binary data) - it isn't used anywhere where it maters. Right now it resolves to empty `PString`. If someone will need to parse those properties for some reason - better file an issue. (It will require adding new enum - PBinary, and subsequent handling of it in all places where this enum is checked)
Fixes #456 