### PR TITLE
Improve h2d.Interactive collision with shape.

### DIFF
--- a/h2d/Interactive.hx
+++ b/h2d/Interactive.hx
@@ -1,10 +1,23 @@
 package h2d;
 
+@:allow(h2d.Scene)
 class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 
+	/**
+		Width of the Interactive. Ignored if `shape` is set.
+	**/
 	public var width : Float;
+	/**
+		Height of the Interactive. Ignored if `shape` is set.
+	**/
 	public var height : Float;
+	/**
+		Cursor used when Interactive is under mouse cursor ( default : Button )
+	**/
 	public var cursor(default,set) : hxd.Cursor;
+	/**
+		Should object collision be in rectangle or ellipse form? Ignored if `shape` is set.
+	**/
 	public var isEllipse : Bool;
 	/**
 		Set the default `cancel` mode (see `hxd.Event`), default to false.
@@ -19,10 +32,11 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 	var scene : Scene;
 	var mouseDownButton : Int = -1;
 	var parentMask : Mask;
+	var invDet : Float;
 
 	/**
 		Detailed shape collider for Interactive.
-		Keep in mind that shape parts that are out of [0, 0, width, height] bounds will never interact with the mouse.
+		If set, `width` and `height` properties are ignored for collision checks.
 	**/
 	public var shape : h2d.col.Collider;
 	/**
@@ -123,7 +137,7 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 				p = @:privateAccess p.parentMask;
 			}
 		}
-		if( isEllipse && checkBounds(e) ) {
+		if(shape == null && isEllipse && checkBounds(e) ) {
 			var cx = width * 0.5, cy = height * 0.5;
 			var dx = (e.relX - cx) / cx;
 			var dy = (e.relY - cy) / cy;
@@ -182,6 +196,12 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 		}
 	}
 
+	override private function calcAbsPos()
+	{
+		super.calcAbsPos();
+		invDet = 1 / (matA * matD - matB * matC);
+	}
+
 	function set_cursor(c) {
 		this.cursor = c;
 		if( isOver() && cursor != null )
@@ -191,25 +211,13 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 
 	function eventToLocal( e : hxd.Event ) {
 		// convert scene event to our local space
-		var rx = e.relX, ry = e.relY;
-
 		var i = this;
 
-		var dx = rx - i.absX;
-		var dy = ry - i.absY;
+		var dx = e.relX - i.absX;
+		var dy = e.relY - i.absY;
 
-		var w1 = i.width * i.matA;
-		var h1 = i.width * i.matC;
-		var ky = h1 * dx - w1 * dy;
-
-		var w2 = i.height * i.matB;
-		var h2 = i.height * i.matD;
-		var kx = w2 * dy - h2 * dx;
-
-		var max = h1 * w2 - w1 * h2;
-
-		e.relX = (kx / max) * i.width;
-		e.relY = (ky / max) * i.height;
+		e.relX = ( dx * i.matD - dy * i.matC) * i.invDet;
+		e.relY = (-dx * i.matB + dy * i.matA) * i.invDet;
 	}
 
 	public function startDrag(callb,?onCancel) {

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -252,31 +252,6 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 			var i = interactive[idx];
 			if( i == null ) break;
 
-			var dx = rx - i.absX;
-			var dy = ry - i.absY;
-
-			var w1 = i.width * i.matA;
-			var h1 = i.width * i.matC;
-			var ky = h1 * dx + w1 * dy;
-
-			// up line
-			if( ky < 0 )
-				continue;
-
-			var w2 = i.height * i.matB;
-			var h2 = i.height * i.matD;
-			var kx = w2 * dy + h2 * dx;
-
-			// left line
-			if( kx < 0 )
-				continue;
-
-			var max = w1 * h2 - h1 * w2;
-
-			// bottom/right
-			if( ky >= max || kx >= max )
-				continue;
-
 			// check visibility
 			var visible = true;
 			var p : Object = i;
@@ -289,13 +264,48 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 			}
 			if( !visible ) continue;
 
-			if (i.shape != null) {
-				pt.set((kx / max) * i.width + i.shapeX, (ky / max) * i.height + i.shapeY);
+			var dx = rx - i.absX;
+			var dy = ry - i.absY;
+
+			if ( i.shape != null ) {
+				// Check collision for Shape Interactive.
+
+				pt.set(( dx * i.matD - dy * i.matC) * i.invDet + i.shapeX,
+				       (-dx * i.matB + dy * i.matA) * i.invDet + i.shapeY);
 				if ( !i.shape.contains(pt) ) continue;
+
+				event.relX = pt.x - i.shapeX;
+				event.relY = pt.y - i.shapeY;
+
+			} else {
+				// Check AABB for width/height Interactive.
+
+				var w1 = i.width * i.matA;
+				var h1 = i.width * i.matC;
+				var ky = h1 * dx + w1 * dy;
+
+				// up line
+				if( ky < 0 )
+					continue;
+
+				var w2 = i.height * i.matB;
+				var h2 = i.height * i.matD;
+				var kx = w2 * dy + h2 * dx;
+
+				// left line
+				if( kx < 0 )
+					continue;
+
+				var max = w1 * h2 - h1 * w2;
+
+				// bottom/right
+				if( ky >= max || kx >= max )
+					continue;
+
+				event.relX = (kx / max) * i.width;
+				event.relY = (ky / max) * i.height;
 			}
 
-			event.relX = (kx / max) * i.width;
-			event.relY = (ky / max) * i.height;
 			i.handleEvent(event);
 
 			if( event.cancel ) {

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -252,18 +252,6 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 			var i = interactive[idx];
 			if( i == null ) break;
 
-			// check visibility
-			var visible = true;
-			var p : Object = i;
-			while( p != null ) {
-				if( !p.visible ) {
-					visible = false;
-					break;
-				}
-				p = p.parent;
-			}
-			if( !visible ) continue;
-
 			var dx = rx - i.absX;
 			var dy = ry - i.absY;
 
@@ -274,8 +262,8 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 				       (-dx * i.matB + dy * i.matA) * i.invDet + i.shapeY);
 				if ( !i.shape.contains(pt) ) continue;
 
-				event.relX = pt.x - i.shapeX;
-				event.relY = pt.y - i.shapeY;
+				dx = pt.x - i.shapeX;
+				dy = pt.y - i.shapeY;
 
 			} else {
 				// Check AABB for width/height Interactive.
@@ -302,9 +290,24 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 				if( ky >= max || kx >= max )
 					continue;
 
-				event.relX = (kx / max) * i.width;
-				event.relY = (ky / max) * i.height;
+				dx = (kx / max) * i.width;
+				dy = (ky / max) * i.height;
 			}
+
+			// check visibility
+			var visible = true;
+			var p : Object = i;
+			while( p != null ) {
+				if( !p.visible ) {
+					visible = false;
+					break;
+				}
+				p = p.parent;
+			}
+			if( !visible ) continue;
+
+			event.relX = dx;
+			event.relY = dy;
 
 			i.handleEvent(event);
 


### PR DESCRIPTION
* Ignore width/height if `shape` is set.
* Add invDet cache to h2d.Interactive
* Simplify `eventToLocal`
* Disable `isEllipse` for shapes.
* Some documentation.
* Visibility check was relocated before collision check.