### PR TITLE
Robust interface to add Converts.

### DIFF
--- a/hxd/fs/Convert.hx
+++ b/hxd/fs/Convert.hx
@@ -2,6 +2,12 @@ package hxd.fs;
 
 class Convert {
 
+	/**
+		Custom list of converts that should be used in FileSystem.
+		Should be added in hxml `--macro` to ensure proper function.
+	**/
+	public static var converts : Array<Convert> = new Array();
+
 	public var sourceExt(default,null) : String;
 	public var destExt(default,null) : String;
 

--- a/hxd/fs/Convert.hx
+++ b/hxd/fs/Convert.hx
@@ -16,7 +16,7 @@ class Convert {
 		`--macro path.to.my.MacroScript.initCustomConverts()`
 	**/
 	public static var converts:Array<String> = new Array();
-	
+
 	static macro function getConverts() : haxe.macro.Expr {
 		var exprs:Array<haxe.macro.Expr> = new Array();
 		var pos = haxe.macro.Context.currentPos();
@@ -30,9 +30,6 @@ class Convert {
 					exprs.push(macro addConvert($newExpr));
 				default:
 			}
-			
-			// trace(macro new $t);
-			// exprs.push(macro addConvert(new $t));
 		}
 		return macro $b{exprs}
 	}

--- a/hxd/fs/Convert.hx
+++ b/hxd/fs/Convert.hx
@@ -5,8 +5,37 @@ class Convert {
 	/**
 		Custom list of converts that should be used in FileSystem.
 		Should be added in hxml `--macro` to ensure proper function.
+		Example of adding a Convert:
+		```haxe
+		static function initCustomConverts() {
+			hxd.fs.Convert.converts.push("path.to.my.Convert");
+			hxd.fs.Convert.converts.push("path.to.my.OtherConvert");
+		}
+		```
+		Adn in hxml:
+		`--macro path.to.my.MacroScript.initCustomConverts()`
 	**/
-	public static var converts : Array<Convert> = new Array();
+	public static var converts:Array<String> = new Array();
+	
+	static macro function getConverts() : haxe.macro.Expr {
+		var exprs:Array<haxe.macro.Expr> = new Array();
+		var pos = haxe.macro.Context.currentPos();
+		
+		for ( p in converts ) {
+			var t = haxe.macro.Context.getType(p);
+			var ct = haxe.macro.TypeTools.toComplexType(t);
+			switch (ct) {
+				case TPath(t):
+					var newExpr : haxe.macro.Expr = { expr: ENew(t, []), pos: pos };
+					exprs.push(macro addConvert($newExpr));
+				default:
+			}
+			
+			// trace(macro new $t);
+			// exprs.push(macro addConvert(new $t));
+		}
+		return macro $b{exprs}
+	}
 
 	public var sourceExt(default,null) : String;
 	public var destExt(default,null) : String;

--- a/hxd/fs/LocalFileSystem.hx
+++ b/hxd/fs/LocalFileSystem.hx
@@ -301,6 +301,9 @@ class LocalFileSystem implements FileSystem {
 		addConvert(new Convert.ConvertFBX2HMD());
 		addConvert(new Convert.ConvertTGA2PNG());
 		addConvert(new Convert.ConvertFNT2BFNT());
+		for ( c in Convert.converts ) {
+			addConvert(c);
+		}
 		#if flash
 		var froot = new flash.filesystem.File(flash.filesystem.File.applicationDirectory.nativePath + "/" + baseDir);
 		if( !froot.exists ) throw "Could not find dir " + dir;

--- a/hxd/fs/LocalFileSystem.hx
+++ b/hxd/fs/LocalFileSystem.hx
@@ -301,7 +301,14 @@ class LocalFileSystem implements FileSystem {
 		addConvert(new Convert.ConvertFBX2HMD());
 		addConvert(new Convert.ConvertTGA2PNG());
 		addConvert(new Convert.ConvertFNT2BFNT());
+		#if macro
+		// In macro context just resolve classes.
+		for ( p in Convert.converts ) {
+			addConvert(Type.createInstance(Type.resolveClass(p), []));
+		}
+		#else
 		@:privateAccess Convert.getConverts();
+		#end
 		#if flash
 		var froot = new flash.filesystem.File(flash.filesystem.File.applicationDirectory.nativePath + "/" + baseDir);
 		if( !froot.exists ) throw "Could not find dir " + dir;

--- a/hxd/fs/LocalFileSystem.hx
+++ b/hxd/fs/LocalFileSystem.hx
@@ -301,9 +301,7 @@ class LocalFileSystem implements FileSystem {
 		addConvert(new Convert.ConvertFBX2HMD());
 		addConvert(new Convert.ConvertTGA2PNG());
 		addConvert(new Convert.ConvertFNT2BFNT());
-		for ( c in Convert.converts ) {
-			addConvert(c);
-		}
+		@:privateAccess Convert.getConverts();
 		#if flash
 		var froot = new flash.filesystem.File(flash.filesystem.File.applicationDirectory.nativePath + "/" + baseDir);
 		if( !froot.exists ) throw "Could not find dir " + dir;


### PR DESCRIPTION
Right now, there's basically no robust way to add Convert to the FileSystem to be executed at compile-time. This PR aims to introduce robust and easy to understand way to do so.
I used same approach as with `hxd.res.Config.extensions` - as in, provide the Convert class.