### PR TITLE
Block keyboard events if the canvas is "focusable" (ie. element==canvas)

### DIFF
--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -54,6 +54,10 @@ class Window {
 		if( element == canvas ) {
 			canvas.setAttribute("tabindex","1"); // allow focus
 			canvas.style.outline = 'none';
+			canvas.addEventListener("keydown", function(e) {
+				e.stopPropagation();
+				e.preventDefault();
+			});
 		} else {
 			canvas.addEventListener("mousedown", function(e) {
 				onMouseDown(e);


### PR DESCRIPTION
Block keyboard events if the canvas is "focusable" (ie. element==canvas) so they don't spread to the document if the canvas is focused.

See issue #494 
[Issue](https://github.com/HeapsIO/heaps/issues/494)