### PR TITLE
Fix Text rendering on texture.

### DIFF
--- a/h2d/Text.hx
+++ b/h2d/Text.hx
@@ -100,7 +100,7 @@ class Text extends Drawable {
 			emitTile(ctx, h2d.Tile.fromColor(0xFF00FF, 16, 16));
 			return;
 		}
-		if ( !calcDone ) initGlyphs(text, false);
+		if ( !calcDone && text != null && font != null ) initGlyphs(text);
 
 		if( dropShadow != null ) {
 			var oldX = absX, oldY = absY;


### PR DESCRIPTION
My initial fix didn't do the proper job.
First, it didn't check for existence of text and font in the first place. Second, it did not use rebuild, which resulted in newly-created Text not populating glyphs.