### PR TITLE
textBaseline bottom for js target in font builder for more even result across browsers

### DIFF
--- a/hxd/res/FontBuilder.hx
+++ b/hxd/res/FontBuilder.hx
@@ -186,6 +186,7 @@ class FontBuilder {
 				if( size == null ) continue;
 				var w = size.w;
 				var h = size.h;
+				if( h > lineH ) lineH = h;
 				// Whatever the first character is it will always have x and y value 0
 				if( x + w > width || i == 0) {
 					x = 0;
@@ -208,7 +209,6 @@ class FontBuilder {
 				all.push(t);
 				font.glyphs.set(options.chars.charCodeAt(i), new h2d.Font.FontChar(t,w - 1));
 				// next element
-				if( h > lineH ) lineH = h;
 				x += w + 1;
 			}
 		} while ( !done );

--- a/hxd/res/FontBuilder.hx
+++ b/hxd/res/FontBuilder.hx
@@ -138,20 +138,19 @@ class FontBuilder {
 		var ctx = bmp.getContext2d();
 		ctx.font = '${this.font.size}px ${this.font.name}';
 		ctx.textAlign = 'left';
-		ctx.textBaseline = 'top'; // important!
+		// bottom textBaseline is the baseline with least difference between browsers
+		ctx.textBaseline = 'bottom'; // important!
 
 		font.lineHeight = 0;
 		var surf = 0;
 		var sizes = [];
 		// get approx height of font including descent
 		var h = getFontHeight(this.font, 'MgO0pj');
-		// arbritrary safety margin used to ensure that char doesn't get scrambled, probably due to messed up text metrics
-		var xMarg = 10;
 		for( i in 0...options.chars.length ) {
 			var textChar = options.chars.charAt(i);
 			var w = Math.ceil(ctx.measureText(textChar).width) + 1;
 			if( w == 1 ) continue;
-			surf += (w + (1 + xMarg)) * (h + 1);
+			surf += (w + 1) * (h + 1);
 			if( h > font.lineHeight )
 				font.lineHeight = h;
 			sizes[i] = { w:w, h:h };
@@ -177,7 +176,7 @@ class FontBuilder {
 			bmp.height = height;
 			ctx.font = '${this.font.size}px ${this.font.name}';
 			ctx.textAlign = 'left';
-			ctx.textBaseline = 'top'; // important!
+			ctx.textBaseline = 'bottom'; // important!
 			ctx.fillStyle = 'red';
 			font.glyphs = new Map();
 			all = [];
@@ -185,9 +184,10 @@ class FontBuilder {
 			for( i in 0...options.chars.length ) {
 				var size = sizes[i];
 				if( size == null ) continue;
-				var w = size.w + xMarg;
+				var w = size.w;
 				var h = size.h;
-				if( x + w > width ) {
+				// Whatever the first character is it will always have x and y value 0
+				if( x + w > width || i == 0) {
 					x = 0;
 					y += lineH + 1;
 				}
@@ -203,9 +203,10 @@ class FontBuilder {
 				ctx.globalAlpha = 1.0;
 				ctx.fillStyle = 'white';
 				ctx.fillText(options.chars.charAt(i), x, y);
-				var t = new h2d.Tile(innerTex, x, y, w - 1, h - 1);
+				// Since we're using bottom textBaseline we need to subtract the height from the y position
+				var t = new h2d.Tile(innerTex, x, y-h, w - 1, h - 1);
 				all.push(t);
-				font.glyphs.set(options.chars.charCodeAt(i), new h2d.Font.FontChar(t,w - (1 + xMarg)));
+				font.glyphs.set(options.chars.charCodeAt(i), new h2d.Font.FontChar(t,w - 1));
 				// next element
 				if( h > lineH ) lineH = h;
 				x += w + 1;


### PR DESCRIPTION
Chrome with their latest [update](https://chromium.googlesource.com/chromium/src/+log/339739f679a9ad4943d77add01513b409f60f416/third_party/blink/renderer/core/html/canvas/text_metrics.cc) adjusted text metric for their baseline value to more correspond to the standard (something only FF has done previously). This however results in varying results across browsers since `top` baseline is calculated differently between browsers. `bottom` however seems to be more even across all browsers (compare this [fiddle](http://jsfiddle.net/j87bY/1/) in FF and Edge/Safari for example). Due to this I suggest using `bottom` as baseline instead.

I've also removed the previously added arbritrary `xMarg` value which was added to prevent artifacts/scrambled chars. Using `bottom` textBaseline seems to prevent previous noted artifacts from occuring.

