### PR TITLE
Add captureSubPixels

### DIFF
--- a/h3d/impl/DirectXDriver.hx
+++ b/h3d/impl/DirectXDriver.hx
@@ -501,20 +501,19 @@ class DirectXDriver extends h3d.impl.Driver {
 		tmp.release();
 	}
 
-	override function capturePixels(tex:h3d.mat.Texture, layer:Int, mipLevel:Int) : hxd.Pixels {
-		var pixels = hxd.Pixels.alloc(tex.width >> mipLevel, tex.height >> mipLevel, tex.format);
-		captureTexPixels(pixels, tex, layer, mipLevel);
-		return pixels;
-	}
-
-	override public function captureSubPixels(tex:h3d.mat.Texture, layer:Int, mipLevel:Int, region:h2d.col.IBounds):hxd.Pixels
-	{
-		if (region.xMax > tex.width) region.xMax = tex.width;
-		if (region.yMax > tex.height) region.yMax = tex.height;
-		if (region.xMin < 0) region.xMin = 0;
-		if (region.yMin < 0) region.yMin = 0;
-		var pixels = hxd.Pixels.alloc(region.width >> mipLevel, region.height >> mipLevel, tex.format);
-		captureTexPixels(pixels, tex, layer, mipLevel, region.xMin, region.yMin);
+	override function capturePixels(tex:h3d.mat.Texture, layer:Int, mipLevel:Int, ?region:h2d.col.IBounds) : hxd.Pixels {
+		var pixels : hxd.Pixels;
+		if (region != null) {
+			if (region.xMax > tex.width) region.xMax = tex.width;
+			if (region.yMax > tex.height) region.yMax = tex.height;
+			if (region.xMin < 0) region.xMin = 0;
+			if (region.yMin < 0) region.yMin = 0;
+			pixels = hxd.Pixels.alloc(region.width >> mipLevel, region.height >> mipLevel, tex.format);
+			captureTexPixels(pixels, tex, layer, mipLevel, region.xMin, region.yMin);
+		} else {
+			pixels = hxd.Pixels.alloc(tex.width >> mipLevel, tex.height >> mipLevel, tex.format);
+			captureTexPixels(pixels, tex, layer, mipLevel);
+		}
 		return pixels;
 	}
 

--- a/h3d/impl/Driver.hx
+++ b/h3d/impl/Driver.hx
@@ -173,12 +173,7 @@ class Driver {
 	public function captureRenderBuffer( pixels : hxd.Pixels ) {
 	}
 
-	public function capturePixels( tex : h3d.mat.Texture, layer : Int, mipLevel : Int ) : hxd.Pixels {
-		throw "Can't capture pixels on this platform";
-		return null;
-	}
-
-	public function captureSubPixels( tex : h3d.mat.Texture, layer : Int, mipLevel : Int, region : h2d.col.IBounds) : hxd.Pixels {
+	public function capturePixels( tex : h3d.mat.Texture, layer : Int, mipLevel : Int, ?region : h2d.col.IBounds ) : hxd.Pixels {
 		throw "Can't capture pixels on this platform";
 		return null;
 	}

--- a/h3d/impl/Driver.hx
+++ b/h3d/impl/Driver.hx
@@ -178,6 +178,11 @@ class Driver {
 		return null;
 	}
 
+	public function captureSubPixels( tex : h3d.mat.Texture, layer : Int, mipLevel : Int, region : h2d.col.IBounds) : hxd.Pixels {
+		throw "Can't capture pixels on this platform";
+		return null;
+	}
+
 	public function getDriverName( details : Bool ) {
 		return "Not available";
 	}

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -1382,24 +1382,23 @@ class GlDriver extends Driver {
 		}
 	}
 
-	override function capturePixels(tex:h3d.mat.Texture, layer:Int, mipLevel:Int) {
-		var pixels = hxd.Pixels.alloc(tex.width >> mipLevel, tex.height >> mipLevel, tex.format);
-		captureTexPixels(pixels, tex, layer, mipLevel, 0, 0);
-		return pixels;
-	}
-
-	override public function captureSubPixels(tex:h3d.mat.Texture, layer:Int, mipLevel:Int, region:h2d.col.IBounds):hxd.Pixels
-	{
-		if (region.xMax > tex.width) region.xMax = tex.width;
-		if (region.yMax > tex.height) region.yMax = tex.height;
-		if (region.xMin < 0) region.xMin = 0;
-		if (region.yMin < 0) region.yMin = 0;
-		var pixels = hxd.Pixels.alloc(region.width >> mipLevel, region.height >> mipLevel, tex.format);
-		captureTexPixels(pixels, tex, layer, mipLevel, region.xMin, region.yMin);
-		return pixels;
-	}
-	
-	function captureTexPixels(pixels:hxd.Pixels, tex:h3d.mat.Texture, layer:Int, mipLevel:Int, x:Int, y:Int) {
+	override function capturePixels(tex:h3d.mat.Texture, layer:Int, mipLevel:Int, ?region:h2d.col.IBounds) {
+		
+		var pixels : hxd.Pixels;
+		var x : Int, y : Int;
+		if (region != null) {
+			if (region.xMax > tex.width) region.xMax = tex.width;
+			if (region.yMax > tex.height) region.yMax = tex.height;
+			if (region.xMin < 0) region.xMin = 0;
+			if (region.yMin < 0) region.yMin = 0;
+			pixels = hxd.Pixels.alloc(region.width >> mipLevel, region.height >> mipLevel, tex.format);
+			x = region.xMin;
+			y = region.yMin;
+		} else {
+			pixels = hxd.Pixels.alloc(tex.width >> mipLevel, tex.height >> mipLevel, tex.format);
+			x = 0;
+			y = 0;
+		}
 		
 		var old = curTarget;
 		var oldCount = numTargets;
@@ -1421,6 +1420,7 @@ class GlDriver extends Driver {
 			setDrawBuffers(oldCount);
 			numTargets = oldCount;
 		}
+		return pixels;
 	}
 
 	override function setRenderTarget( tex : h3d.mat.Texture, layer = 0, mipLevel = 0 ) {

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -1592,7 +1592,7 @@ class GlDriver extends Driver {
 		captureSubRenderBuffer(pixels, 0, 0);
 	}
 
-	inline function captureSubRenderBuffer( pixels : hxd.Pixels, x : Int, y : Int ) {
+	function captureSubRenderBuffer( pixels : hxd.Pixels, x : Int, y : Int ) {
 		if( curTarget == null )
 			throw "Can't capture main render buffer in GL";
 		discardError();

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -1383,6 +1383,24 @@ class GlDriver extends Driver {
 	}
 
 	override function capturePixels(tex:h3d.mat.Texture, layer:Int, mipLevel:Int) {
+		var pixels = hxd.Pixels.alloc(tex.width >> mipLevel, tex.height >> mipLevel, tex.format);
+		captureTexPixels(pixels, tex, layer, mipLevel, 0, 0);
+		return pixels;
+	}
+
+	override public function captureSubPixels(tex:h3d.mat.Texture, layer:Int, mipLevel:Int, region:h2d.col.IBounds):hxd.Pixels
+	{
+		if (region.xMax > tex.width) region.xMax = tex.width;
+		if (region.yMax > tex.height) region.yMax = tex.height;
+		if (region.xMin < 0) region.xMin = 0;
+		if (region.yMin < 0) region.yMin = 0;
+		var pixels = hxd.Pixels.alloc(region.width >> mipLevel, region.height >> mipLevel, tex.format);
+		captureTexPixels(pixels, tex, layer, mipLevel, region.xMin, region.yMin);
+		return pixels;
+	}
+	
+	function captureTexPixels(pixels:hxd.Pixels, tex:h3d.mat.Texture, layer:Int, mipLevel:Int, x:Int, y:Int) {
+		
 		var old = curTarget;
 		var oldCount = numTargets;
 		var oldLayer = curTargetLayer;
@@ -1394,8 +1412,7 @@ class GlDriver extends Driver {
 					gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0+i,GL.TEXTURE_2D,null,0);
 		}
 		setRenderTarget(tex, layer, mipLevel);
-		var pixels = hxd.Pixels.alloc(tex.width >> mipLevel, tex.height >> mipLevel, tex.format);
-		captureRenderBuffer(pixels);
+		captureSubRenderBuffer(pixels, x, y);
 		setRenderTarget(old, oldLayer, oldMip);
 		if( oldCount > 1 ) {
 			for( i in 1...oldCount )
@@ -1404,7 +1421,6 @@ class GlDriver extends Driver {
 			setDrawBuffers(oldCount);
 			numTargets = oldCount;
 		}
-		return pixels;
 	}
 
 	override function setRenderTarget( tex : h3d.mat.Texture, layer = 0, mipLevel = 0 ) {
@@ -1573,6 +1589,10 @@ class GlDriver extends Driver {
 	#end
 
 	override function captureRenderBuffer( pixels : hxd.Pixels ) {
+		captureSubRenderBuffer(pixels, 0, 0);
+	}
+
+	inline function captureSubRenderBuffer( pixels : hxd.Pixels, x : Int, y : Int ) {
 		if( curTarget == null )
 			throw "Can't capture main render buffer in GL";
 		discardError();
@@ -1588,7 +1608,7 @@ class GlDriver extends Driver {
 		var buffer = @:privateAccess pixels.bytes.b;
 		#end
 		#if (js || hl)
-		gl.readPixels(0, 0, pixels.width, pixels.height, getChannels(curTarget.t), curTarget.t.pixelFmt, buffer);
+		gl.readPixels(x, y, pixels.width, pixels.height, getChannels(curTarget.t), curTarget.t.pixelFmt, buffer);
 		var error = gl.getError();
 		if( error != 0 ) throw "Failed to capture pixels (error "+error+")";
 		@:privateAccess pixels.innerFormat = curTarget.format;

--- a/h3d/mat/Texture.hx
+++ b/h3d/mat/Texture.hx
@@ -300,15 +300,16 @@ class Texture {
 		Downloads the current texture data from the GPU.
 		Beware, this is a very slow operation that shouldn't be done during rendering.
 	**/
-	public function capturePixels( face = 0, mipLevel = 0 ) : hxd.Pixels {
+	public function capturePixels( face = 0, mipLevel = 0, ?region:h2d.col.IBounds ) : hxd.Pixels {
 		#if flash
 		if( flags.has(Cube) ) throw "Can't capture cube texture on this platform";
+		if( region != null ) throw "Can't capture texture region on this platform";
 		if( face != 0 || mipLevel != 0 ) throw "Can't capture face/mipLevel on this platform";
 		return capturePixelsFlash();
 		#else
 		var old = lastFrame;
 		preventAutoDispose();
-		var pix = mem.driver.capturePixels(this, face, mipLevel);
+		var pix = region != null ? mem.driver.captureSubPixels(this, face, mipLevel, region) : mem.driver.capturePixels(this, face, mipLevel);
 		lastFrame = old;
 		return pix;
 		#end

--- a/h3d/mat/Texture.hx
+++ b/h3d/mat/Texture.hx
@@ -309,7 +309,7 @@ class Texture {
 		#else
 		var old = lastFrame;
 		preventAutoDispose();
-		var pix = region != null ? mem.driver.captureSubPixels(this, face, mipLevel, region) : mem.driver.capturePixels(this, face, mipLevel);
+		var pix = mem.driver.capturePixels(this, face, mipLevel, region);
 		lastFrame = old;
 		return pix;
 		#end


### PR DESCRIPTION
- Adds `Driver.captureSubPixels` function with `bounds:h2d.col.IBounds` argument that allows to capture only region of the texture. Implemented on GL and DX drivers.
- Adds optional bounds argument to `Texture.capturePixels`.

Reasoning:
Sometimes you don't need entire texture pixel data captured, but only specific region of it. This provides robust API to do so.