### PR TITLE
Fix BFont text format not parsing last value

### DIFF
--- a/hxd/fmt/bfnt/FontParser.hx
+++ b/hxd/fmt/bfnt/FontParser.hx
@@ -117,7 +117,7 @@ class FontParser {
 			var lines = bytes.toString().split("\n");
 			
 			// BMFont pads values with spaces, littera doesn't.
-			var reg = ~/ *?([0-9a-zA-Z]+)=("[^"]+"|.+?)(?: |$)/;
+			var reg = ~/ *?([0-9a-zA-Z]+)=("[^"]+"|.+?)(?:[ \r]|$)/;
 			var idx : Int;
 			
 			inline function next() : Void {


### PR DESCRIPTION
Happens if there's no trailing spaces and used CRLF line endings.