### PR TITLE
Fixes to `h2d.HtmlText`

### DIFF
--- a/h2d/HtmlText.hx
+++ b/h2d/HtmlText.hx
@@ -83,7 +83,7 @@ class HtmlText extends Text {
 		prevChar = -1;
 		newLine = true;
 		for( e in doc )
-			buildSizes(e, sizes);
+			buildSizes(e, font, sizes);
 
 		prevChar = -1;
 		newLine = true;
@@ -101,9 +101,9 @@ class HtmlText extends Text {
 		calcDone = true;
 	}
 
-	function buildSizes( e : Xml, sizes : Array<Int> ) {
+	function buildSizes( e : Xml, font : Font, sizes : Array<Int> ) {
 		if( e.nodeType == Xml.Element ) {
-			var len = 0, prevFont = font;
+			var len = 0;
 			var nodeName = e.nodeName.toLowerCase();
 			switch( nodeName ) {
 			case "p":
@@ -131,14 +131,13 @@ class HtmlText extends Text {
 			}
 			sizes.push(len);
 			for( child in e )
-				buildSizes(child, sizes);
+				buildSizes(child, font, sizes);
 			switch( nodeName ) {
 			case "p":
 				sizes.push( -1);// break
 				newLine = true;
 			default:
 			}
-			font = prevFont;
 		} else {
 			newLine = false;
 			var text = htmlToText(e.nodeValue);
@@ -219,6 +218,18 @@ class HtmlText extends Text {
 						if( prevGlyphs == null ) prevGlyphs = glyphs;
 						var prev = glyphs;
 						glyphs = new TileGroup(font == null ? null : font.tile, this);
+						if ( font != null ) {
+							switch( font.type ) {
+								case SignedDistanceField(channel, alphaCutoff, smoothing):
+									var shader = new h3d.shader.SignedDistanceField();
+									shader.channel = channel;
+									shader.alphaCutoff = alphaCutoff;
+									shader.smoothing = smoothing;
+									glyphs.smooth = true;
+									glyphs.addShader(shader);
+								default:
+							}
+						}
 						@:privateAccess glyphs.curColor.load(prev.curColor);
 						elements.push(glyphs);
 					default:


### PR DESCRIPTION
* Fix `<font face` causing rebuild recursion due to `buildSizes` assigning font, which caused `rebuild` which caused `buildSizes` assigning font, which caused `rebuild`, which caused...
* Fix SDF font rendering as non-main font. If SDF font was assigned via `<font face`, it did not had an SDF shader assigned, rendering raw SDF texture instead of proper glyph. 

Personal remark: HtmlText is a mess in general. Having different size fonts breaks word-wrap, vertical spacing, alignment, etc. And adding `<p align` support in current implementation is not as trivial as just always calculating lines. 