### PR TITLE
Add standard cursor override ability.

### DIFF
--- a/hxd/Cursor.hx
+++ b/hxd/Cursor.hx
@@ -12,6 +12,25 @@ enum Cursor {
 @:allow(hxd.System)
 class CustomCursor {
 
+	static var cursorOverrides:Map<Cursor, Cursor> = new Map();
+
+	/**
+		Allows to override default cursors by custom ones.
+		Custom and Hide cursor cannot be overriden.
+		Passing `null` to as `by` will remove cursor override.
+	**/
+	public static function setCursorOverride(cur:Cursor, by:CustomCursor):Void {
+		switch( cur ) {
+			case Custom(_), Hide:
+				// Ignore, can't override.
+			default:
+				if ( by == null )
+					cursorOverrides.remove(cur);
+				else
+					cursorOverrides.set(cur, Custom(by));
+		}
+	}
+
 	var frames : Array<hxd.BitmapData>;
 	var speed : Float;
 	var offsetX : Int;

--- a/hxd/System.flash.hx
+++ b/hxd/System.flash.hx
@@ -60,6 +60,8 @@ class System {
 	}
 
 	public static function setNativeCursor( c : Cursor ) : Void {
+		var overrideCursor = hxd.Cursor.CustomCursor.cursorOverrides.get(c);
+		if (overrideCursor != null) c = overrideCursor;
 		flash.ui.Mouse.cursor = switch( c ) {
 		case Default: "auto";
 		case Button: "button";

--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -179,6 +179,8 @@ class System {
 			Cursor.show(false);
 			return;
 		}
+		var overrideCursor = hxd.Cursor.CustomCursor.cursorOverrides.get(c);
+		if (overrideCursor != null) c = overrideCursor;
 		var cur : Cursor;
 		switch( c ) {
 		case Default:

--- a/hxd/System.js.hx
+++ b/hxd/System.js.hx
@@ -67,6 +67,8 @@ class System {
 		currentCustomCursor = null;
 		var canvas = @:privateAccess hxd.Window.getInstance().canvas;
 		if( canvas != null ) {
+			var overrideCursor = hxd.Cursor.CustomCursor.cursorOverrides.get(c);
+			if (overrideCursor != null) c = overrideCursor;
 			canvas.style.cursor = switch( c ) {
 			case Default: "default";
 			case Button: "pointer";

--- a/samples/Cursor.hx
+++ b/samples/Cursor.hx
@@ -1,6 +1,7 @@
-class Cursor extends hxd.App {
+class Cursor extends SampleApp {
 	
 	override function init() {
+		super.init();
 
 		engine.backgroundColor = 0xFF202020;
 
@@ -30,7 +31,7 @@ class Cursor extends hxd.App {
 		}
 		
 		var cursors : Array<hxd.Cursor> = [Default,Button,Move,TextInput,Hide,Custom(new hxd.Cursor.CustomCursor([bmp],10,16,16)),Custom(new hxd.Cursor.CustomCursor(animatedFrames,10,16,16))];
-		var pos = 0;
+		var pos = 3;
 		for( c in cursors ) {
 			var i = new h2d.Interactive(120, 20, s2d);
 			var tf = new h2d.Text(hxd.res.DefaultFont.get(), i);
@@ -57,6 +58,20 @@ class Cursor extends hxd.App {
 				default:
 			}
 		}
+
+		// It's possible to override default cursors by Custom ones.
+		// Useful when game utilizes stylized cursors for everything.
+		var doOverride = false;
+		var defOverride = new hxd.BitmapData(10, 10);
+		defOverride.line(0, 0, 5, 0, 0xffff0000);
+		defOverride.line(0, 1, 0, 5, 0xffff0000);
+		defOverride.line(0, 0, 10, 10, 0xffff0000);
+
+		addText("Override Default cursor by Custom");
+		addCheck("Enable", function() { return doOverride; }, function(v) {
+			doOverride = v;
+			hxd.Cursor.CustomCursor.setCursorOverride(Default, v ? new hxd.Cursor.CustomCursor([defOverride],10,0,0) : null);
+		});
 	}
 
 	static function main() {


### PR DESCRIPTION
Introduces `hxd.Cursor.CustomCursor.setCursorOverride` function that allows override of standard cursors. As in: `Default`, `Button`, `Move` and `TextInput`. Custom and Hide cursors cannot be overridden. 
While it's possible to simulate this override manually, it's very hacky and bothersome to do. (setting cursor to each Interactive, using `@:privateAccess` to override TextInput cursor, dealing with Default cursor, etc)
Cursor sample updated to showcase feature as well.