### PR TITLE
Actually call `onCancel` during `stopDrag`

### DIFF
--- a/hxd/SceneEvents.hx
+++ b/hxd/SceneEvents.hx
@@ -315,6 +315,8 @@ class SceneEvents {
 	}
 
 	public function stopDrag() {
+		if( currentDrag != null && currentDrag.onCancel != null )
+			currentDrag.onCancel();
 		currentDrag = null;
 	}
 


### PR DESCRIPTION
Why nobody noticed it before? Especially given the fact that docs specify `onCancel` being called on `stopDrag` (in `h2d.Scene`). 
👍 