### PR TITLE
Flip Cylinder UV coords

### DIFF
--- a/h3d/prim/Cylinder.hx
+++ b/h3d/prim/Cylinder.hx
@@ -27,10 +27,10 @@ class Cylinder extends Quads {
 		for( s in 0...segs ) {
 			var u = s / segs;
 			var u2 = (s + 1) / segs;
-			uvs.push(new UV(u, 1));
-			uvs.push(new UV(u2, 1));
 			uvs.push(new UV(u, 0));
 			uvs.push(new UV(u2, 0));
+			uvs.push(new UV(u, 1));
+			uvs.push(new UV(u2, 1));
 		}
 	}
 


### PR DESCRIPTION
Just started using 3D in heaps, so let me know if I'm getting this wrong, but it seems to me like UV coords for cylinder primitive are inverted, resulting in a flipped texture