### PR TITLE
Fix/improve h2d.Layers

### DIFF
--- a/h2d/Interactive.hx
+++ b/h2d/Interactive.hx
@@ -72,21 +72,15 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 		if( backgroundColor != null || forSize ) addBounds(relativeTo, out, 0, 0, Std.int(width), Std.int(height));
 	}
 
-	override function onParentChanged() {
-		super.onParentChanged();
+	override private function onHierarchyMoved(parentChanged:Bool)
+	{
+		super.onHierarchyMoved(parentChanged);
 		if( scene != null ) {
 			scene.removeEventTarget(this);
 			scene.addEventTarget(this);
 		}
-		updateMask();
-	}
-
-	override function onOrderChanged() {
-		super.onOrderChanged();
-		if (scene != null) {
-			scene.removeEventTarget(this);
-			scene.addEventTarget(this);
-		}
+		if ( parentChanged )
+			updateMask();
 	}
 
 	function updateMask() {

--- a/h2d/Interactive.hx
+++ b/h2d/Interactive.hx
@@ -81,6 +81,14 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 		updateMask();
 	}
 
+	override function onOrderChanged() {
+		super.onOrderChanged();
+		if (scene != null) {
+			scene.removeEventTarget(this);
+			scene.addEventTarget(this);
+		}
+	}
+
 	function updateMask() {
 		parentMask = null;
 		var p = parent;

--- a/h2d/Layers.hx
+++ b/h2d/Layers.hx
@@ -129,13 +129,13 @@ class Layers extends Object {
 	/**
 		Moves Object to specified index on it's layer.
 	**/
-	public function moveTo( s : Object, index : Int ) {
+	public function moveChild( s : Object, index : Int ) {
 		for( i in 0...children.length )
 			if ( children[i] == s ) {
 				var pos = 0;
 				for ( l in layersIndexes )
 					if ( l > i ) {
-						if ( (l - pos) >= index ) index = l - pos - 1;
+						if ( index >= (l - pos) ) index = l - pos - 1;
 						break;
 					} else {
 						pos = l;
@@ -149,7 +149,7 @@ class Layers extends Object {
 					}
 				} else { // over
 					pos += index;
-					for ( p in i...pos-1 )
+					for ( p in i...pos )
 						children[p] = children[p + 1];
 				}
 				children[pos] = s;

--- a/h2d/Layers.hx
+++ b/h2d/Layers.hx
@@ -102,7 +102,8 @@ class Layers extends Object {
 				}
 				children[pos] = s;
 				// Force Interactive to reattach to scene in order to keep interaction order.
-				s.onOrderChanged();
+				if ( s.allocated )
+					s.onHierarchyMoved(false);
 				return;
 			}
 	}
@@ -119,7 +120,8 @@ class Layers extends Object {
 							children[p] = children[p + 1];
 						children[l - 1] = s;
 						// Force Interactive to reattach to scene in order to keep interaction order.
-						s.onOrderChanged();
+						if ( s.allocated )
+							s.onHierarchyMoved(false);
 						return;
 					}
 				return;
@@ -153,7 +155,8 @@ class Layers extends Object {
 						children[p] = children[p + 1];
 				}
 				children[pos] = s;
-				s.onOrderChanged();
+				if ( s.allocated )
+					s.onHierarchyMoved(false);
 				return;
 			}
 	}
@@ -238,7 +241,8 @@ class Layers extends Object {
 					p--;
 				}
 				children[p + 1] = c;
-				c.onOrderChanged();
+				if ( c.allocated )
+					c.onHierarchyMoved(false);
 			} else
 				ymax = c.y;
 			pos++;

--- a/h2d/Layers.hx
+++ b/h2d/Layers.hx
@@ -20,35 +20,6 @@ class Layers extends Object {
 		return addChildAt(s, layer);
 	}
 
-	/**
-		Adds an Object to specified layer and specified index of that layer.
-	**/
-	public function addAt(s : Object, layer : Int, index : Int) {
-		if ( layer >= layerCount ) {
-			add(s, layer);
-			return;
-		}
-
-		if ( s.parent == this ) {
-			var old = s.allocated;
-			s.allocated = false;
-			removeChild(s);
-			s.allocated = old;
-		}
-		if ( index <= 0 ) {
-			super.addChildAt(s, layer == 0 ? 0 : layersIndexes[layer - 1]);
-		} else {
-			var start = layer == 0 ? 0 : layersIndexes[layer - 1];
-			if (layersIndexes[layer] - start >= index)
-				super.addChildAt(s, layersIndexes[layer]);
-			else
-				super.addChildAt(s, start + index);
-		}
-
-		for ( i in layer...layerCount )
-			layersIndexes[i]++;
-	}
-
 	override function addChildAt( s : Object, layer : Int ) {
 		if( s.parent == this ) {
 			var old = s.allocated;
@@ -129,39 +100,6 @@ class Layers extends Object {
 	}
 
 	/**
-		Moves Object to specified index on it's layer.
-	**/
-	public function moveChild( s : Object, index : Int ) {
-		for( i in 0...children.length )
-			if ( children[i] == s ) {
-				var pos = 0;
-				for ( l in layersIndexes )
-					if ( l > i ) {
-						if ( index >= (l - pos) ) index = l - pos - 1;
-						break;
-					} else {
-						pos = l;
-					}
-				if ( (i - pos) > index ) { // under
-					if ( index > 0 ) pos += index;
-					var p = i;
-					while ( p > pos ) {
-						children[p] = children[p - 1];
-						p--;
-					}
-				} else { // over
-					pos += index;
-					for ( p in i...pos )
-						children[p] = children[p + 1];
-				}
-				children[pos] = s;
-				if ( s.allocated )
-					s.onHierarchyMoved(false);
-				return;
-			}
-	}
-
-	/**
 		Returns Iterator of objects contained in specified layer.  
 		Returns empty iterator if layer does not exists.  
 		Objects added or removed from Layers during iteration are not added/removed from the Iterator.
@@ -188,19 +126,6 @@ class Layers extends Object {
 		var index = children.indexOf(s);
 		for ( i in 0...layerCount )
 			if ( layersIndexes[i] > index ) return i;
-		return -1;
-	}
-
-	/**
-		Finds the index of a child in it's layer.  
-		Always returns -1 if provided Object is not a child of Layer.
-	**/
-	public function getChildLayerIndex( s : Object ) : Int {
-		if ( s.parent != this ) return -1;
-
-		var index = children.indexOf(s);
-		for ( i in 0...layerCount )
-			if ( layersIndexes[i] > index ) return (i == 0 ? index : index - layersIndexes[i - 1]);
 		return -1;
 	}
 

--- a/h2d/Layers.hx
+++ b/h2d/Layers.hx
@@ -69,7 +69,9 @@ class Layers extends Object {
 					p--;
 				}
 				children[pos] = s;
-				break;
+				// Force Interactive to reattach to scene in order to keep interaction order.
+				s.onOrderChanged();
+				return;
 			}
 	}
 
@@ -81,9 +83,11 @@ class Layers extends Object {
 						for( p in i...l-1 )
 							children[p] = children[p + 1];
 						children[l - 1] = s;
-						break;
+						// Force Interactive to reattach to scene in order to keep interaction order.
+						s.onOrderChanged();
+						return;
 					}
-				break;
+				return;
 			}
 	}
 
@@ -133,6 +137,7 @@ class Layers extends Object {
 					p--;
 				}
 				children[p + 1] = c;
+				c.onOrderChanged();
 			} else
 				ymax = c.y;
 			pos++;

--- a/h2d/Layers.hx
+++ b/h2d/Layers.hx
@@ -20,6 +20,35 @@ class Layers extends Object {
 		return addChildAt(s, layer);
 	}
 
+	/**
+		Adds an Object to specified layer and specified index of that layer.
+	**/
+	public function addAt(s : Object, layer : Int, index : Int) {
+		if ( layer >= layerCount ) {
+			add(s, layer);
+			return;
+		}
+
+		if ( s.parent == this ) {
+			var old = s.allocated;
+			s.allocated = false;
+			removeChild(s);
+			s.allocated = old;
+		}
+		if ( index <= 0 ) {
+			super.addChildAt(s, layer == 0 ? 0 : layersIndexes[layer - 1]);
+		} else {
+			var start = layer == 0 ? 0 : layersIndexes[layer - 1];
+			if (layersIndexes[layer] - start >= index)
+				super.addChildAt(s, layersIndexes[layer]);
+			else
+				super.addChildAt(s, start + index);
+		}
+
+		for ( i in layer...layerCount )
+			layersIndexes[i]++;
+	}
+
 	override function addChildAt( s : Object, layer : Int ) {
 		if( s.parent == this ) {
 			var old = s.allocated;
@@ -98,6 +127,38 @@ class Layers extends Object {
 	}
 
 	/**
+		Moves Object to specified index on it's layer.
+	**/
+	public function moveTo( s : Object, index : Int ) {
+		for( i in 0...children.length )
+			if ( children[i] == s ) {
+				var pos = 0;
+				for ( l in layersIndexes )
+					if ( l > i ) {
+						if ( (l - pos) >= index ) index = l - pos - 1;
+						break;
+					} else {
+						pos = l;
+					}
+				if ( (i - pos) > index ) { // under
+					if ( index > 0 ) pos += index;
+					var p = i;
+					while ( p > pos ) {
+						children[p] = children[p - 1];
+						p--;
+					}
+				} else { // over
+					pos += index;
+					for ( p in i...pos-1 )
+						children[p] = children[p + 1];
+				}
+				children[pos] = s;
+				s.onOrderChanged();
+				return;
+			}
+	}
+
+	/**
 		Returns Iterator of objects contained in specified layer.  
 		Returns empty iterator if layer does not exists.  
 		Objects added or removed from Layers during iteration are not added/removed from the Iterator.
@@ -115,16 +176,29 @@ class Layers extends Object {
 	}
 
 	/**
-		Find the layer on which child object resides.  
-		Always returns 0 if provided Object is not a child of Layers.
+		Finds the layer on which child object resides.  
+		Always returns -1 if provided Object is not a child of Layers.
 	**/
 	public function getChildLayer( s : Object ) : Int {
-		if ( s.parent != this ) return 0;
+		if ( s.parent != this ) return -1;
 
 		var index = children.indexOf(s);
 		for ( i in 0...layerCount )
-			if ( layersIndexes[i] > index ) return i - 1;
-		return layerCount - 1;
+			if ( layersIndexes[i] > index ) return i;
+		return -1;
+	}
+
+	/**
+		Finds the index of a child in it's layer.  
+		Always returns -1 if provided Object is not a child of Layer.
+	**/
+	public function getChildLayerIndex( s : Object ) : Int {
+		if ( s.parent != this ) return -1;
+
+		var index = children.indexOf(s);
+		for ( i in 0...layerCount )
+			if ( layersIndexes[i] > index ) return (i == 0 ? index : index - layersIndexes[i - 1]);
+		return -1;
 	}
 
 	function drawLayer( ctx : RenderContext, layer : Int ) {

--- a/h2d/Layers.hx
+++ b/h2d/Layers.hx
@@ -54,6 +54,9 @@ class Layers extends Object {
 		}
 	}
 
+	/**
+		Moves Object to the bottom of its layer (rendered first, behind the other Objects in layer).
+	**/
 	public function under( s : Object ) {
 		for( i in 0...children.length )
 			if( children[i] == s ) {
@@ -75,6 +78,9 @@ class Layers extends Object {
 			}
 	}
 
+	/**
+		Moves Object to the top of its layer (rendered last, in front of other Objects in layer).
+	**/
 	public function over( s : Object ) {
 		for( i in 0...children.length )
 			if( children[i] == s ) {
@@ -91,6 +97,11 @@ class Layers extends Object {
 			}
 	}
 
+	/**
+		Returns Iterator of objects contained in specified layer.  
+		Returns empty iterator if layer does not exists.  
+		Objects added or removed from Layers during iteration are not added/removed from the Iterator.
+	**/
 	public function getLayer( layer : Int ) : Iterator<Object> {
 		var a;
 		if( layer >= layerCount )
@@ -101,6 +112,19 @@ class Layers extends Object {
 			a = children.slice(start, max);
 		}
 		return new hxd.impl.ArrayIterator(a);
+	}
+
+	/**
+		Find the layer on which child object resides.  
+		Always returns 0 if provided Object is not a child of Layers.
+	**/
+	public function getChildLayer( s : Object ) : Int {
+		if ( s.parent != this ) return 0;
+
+		var index = children.indexOf(s);
+		for ( i in 0...layerCount )
+			if ( layersIndexes[i] > index ) return i - 1;
+		return layerCount - 1;
 	}
 
 	function drawLayer( ctx : RenderContext, layer : Int ) {
@@ -118,6 +142,9 @@ class Layers extends Object {
 		ctx.globalAlpha = old;
 	}
 
+	/**
+		Sorts specified layer based on Y value of it's Objects.
+	**/
 	public function ysort( layer : Int ) {
 		if( layer >= layerCount ) return;
 		var start = layer == 0 ? 0 : layersIndexes[layer - 1];

--- a/h2d/Mask.hx
+++ b/h2d/Mask.hx
@@ -12,9 +12,10 @@ class Mask extends Object {
 		this.height = height;
 	}
 
-	override function onParentChanged() {
-		super.onParentChanged();
-		updateMask();
+	override private function onHierarchyMoved(parentChanged:Bool) {
+		super.onHierarchyMoved(parentChanged);
+		if ( parentChanged )
+			updateMask();
 	}
 
 	override function onAdd() {

--- a/h2d/Object.hx
+++ b/h2d/Object.hx
@@ -347,7 +347,7 @@ class Object {
 			if( !s.allocated )
 				s.onAdd();
 			else
-				s.onParentChanged();
+				s.onHierarchyMoved(true);
 		}
 		onContentChanged();
 	}
@@ -357,15 +357,18 @@ class Object {
 	}
 
 	// called when we're allocated already but moved in hierarchy
-	function onParentChanged() {
-		for( c in children )
-			c.onParentChanged();
+	function onHierarchyMoved( parentChanged:Bool ) {
+		for ( c in children )
+			c.onHierarchyMoved(parentChanged);
+		// Compat
+		if ( parentChanged )
+			onParentChanged();
 	}
 
-	// called when underlying Layers (Scene or otherwise) change the order of the rendering.
-	function onOrderChanged() {
-		for ( c in children )
-			c.onOrderChanged();
+	/**
+		Kept for compatibility, use `onHierarchyMoved` instead.
+	**/
+	function onParentChanged() {
 	}
 
 	// kept for internal init
@@ -424,7 +427,7 @@ class Object {
 
 	/**
 		Same as parent.removeChild(this), but does nothing if parent is null.
-		In order to capture add/removal from scene, you can override onAdd/onRemove/onParentChanged
+		In order to capture add/removal from scene, you can override onAdd/onRemove/onHierarchyMoved
 	**/
 	public inline function remove() {
 		if( this != null && parent != null ) parent.removeChild(this);

--- a/h2d/Object.hx
+++ b/h2d/Object.hx
@@ -357,18 +357,9 @@ class Object {
 	}
 
 	// called when we're allocated already but moved in hierarchy
-	function onHierarchyMoved( parentChanged:Bool ) {
+	function onHierarchyMoved( parentChanged : Bool ) {
 		for ( c in children )
 			c.onHierarchyMoved(parentChanged);
-		// Compat
-		if ( parentChanged )
-			onParentChanged();
-	}
-
-	/**
-		Kept for compatibility, use `onHierarchyMoved` instead.
-	**/
-	function onParentChanged() {
 	}
 
 	// kept for internal init

--- a/h2d/Object.hx
+++ b/h2d/Object.hx
@@ -362,6 +362,12 @@ class Object {
 			c.onParentChanged();
 	}
 
+	// called when underlying Layers (Scene or otherwise) change the order of the rendering.
+	function onOrderChanged() {
+		for ( c in children )
+			c.onOrderChanged();
+	}
+
 	// kept for internal init
 	function onAdd() {
 		allocated = true;


### PR DESCRIPTION
* Added `Object.onOrderChanged` called when changing object ordering in `h2d.Layers`.
* Fixed `h2d.Interactive` not updating it's interaction order when using `over`, `under` or `ysort`.
* Added more features to Layers
  * `getChildLayer` - returns layer on which specified child resides.
  * `getChildLayerIndex` - returns index of a child relative to it's layer.
  * `addAt` - adds child to specific layer and index of that layer. Useful for people who use `Object.addChildAt` and want to utilize adding at index with Layers.
  * `moveChild` - moves Object within layer. Allows for more refined reordering within layer boundaries compared to `over`/`under`.
* Added documentation to functions.

Fixes issue described here: https://community.heaps.io/t/interactives-overlap-layers/160
Edit: Build fails due to PR using failing master build. Has nothing to do with actual PR.