### PR TITLE
Implement multiple Overs for Interactives

### DIFF
--- a/h2d/Interactive.hx
+++ b/h2d/Interactive.hx
@@ -174,12 +174,8 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 			mouseDownButton = -1;
 		case EOver:
 			onOver(e);
-			if( !e.cancel && cursor != null )
-				hxd.System.setCursor(cursor);
 		case EOut:
 			onOut(e);
-			if( !e.cancel )
-				hxd.System.setCursor(Default);
 		case EWheel:
 			onWheel(e);
 		case EFocusLost:
@@ -205,8 +201,8 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 
 	function set_cursor(c) {
 		this.cursor = c;
-		if( isOver() && cursor != null )
-			hxd.System.setCursor(cursor);
+		if ( scene != null && scene.events != null )
+			scene.events.updateCursor(this);
 		return c;
 	}
 

--- a/h2d/Interactive.hx
+++ b/h2d/Interactive.hx
@@ -177,7 +177,6 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 			if( !e.cancel && cursor != null )
 				hxd.System.setCursor(cursor);
 		case EOut:
-			mouseDownButton = -1;
 			onOut(e);
 			if( !e.cancel )
 				hxd.System.setCursor(Default);

--- a/h2d/Interactive.hx
+++ b/h2d/Interactive.hx
@@ -246,7 +246,7 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 	}
 
 	public function isOver() {
-		return scene != null && scene.events != null && @:privateAccess scene.events.currentOver == this;
+		return scene != null && scene.events != null && @:privateAccess scene.events.overList.indexOf(this) != -1;
 	}
 
 	public function hasFocus() {

--- a/h3d/scene/Interactive.hx
+++ b/h3d/scene/Interactive.hx
@@ -97,7 +97,6 @@ class Interactive extends Object implements hxd.SceneEvents.Interactive {
 			if( !e.cancel && cursor != null )
 				hxd.System.setCursor(cursor);
 		case EOut:
-			mouseDownButton = -1;
 			onOut(e);
 			if( !e.cancel )
 				hxd.System.setCursor(Default);
@@ -136,7 +135,7 @@ class Interactive extends Object implements hxd.SceneEvents.Interactive {
 	}
 
 	public function isOver() {
-		return scene != null && scene.events != null && @:privateAccess scene.events.currentOver == this;
+		return scene != null && scene.events != null && @:privateAccess scene.events.overList.indexOf(this) != -1;
 	}
 
 	public function hasFocus() {

--- a/h3d/scene/Interactive.hx
+++ b/h3d/scene/Interactive.hx
@@ -94,12 +94,8 @@ class Interactive extends Object implements hxd.SceneEvents.Interactive {
 			mouseDownButton = -1;
 		case EOver:
 			onOver(e);
-			if( !e.cancel && cursor != null )
-				hxd.System.setCursor(cursor);
 		case EOut:
 			onOut(e);
-			if( !e.cancel )
-				hxd.System.setCursor(Default);
 		case EWheel:
 			onWheel(e);
 		case EFocusLost:
@@ -119,8 +115,8 @@ class Interactive extends Object implements hxd.SceneEvents.Interactive {
 
 	function set_cursor(c) {
 		this.cursor = c;
-		if( isOver() && cursor != null )
-			hxd.System.setCursor(cursor);
+		if ( scene != null && scene.events != null )
+			scene.events.updateCursor(this);
 		return c;
 	}
 

--- a/hxd/SceneEvents.hx
+++ b/hxd/SceneEvents.hx
@@ -236,8 +236,7 @@ class SceneEvents {
 					overList.remove(overList[idx]);
 					continue;
 				}
-				idx--;
-			} while ( idx > overIndex );
+			} while ( --idx >= overIndex );
 			updateCursor = true;
 		}
 		if ( updateCursor )

--- a/hxd/SceneEvents.hx
+++ b/hxd/SceneEvents.hx
@@ -190,13 +190,6 @@ class SceneEvents {
 							fillOver = i.propagateEvents;
 							overIndex++;
 						}
-						var idx = 0;
-						while ( idx < overList.length ) {
-							var o = overList[idx];
-							if ( o == i ) {
-							}
-							idx++;
-						}
 					}
 				} else {
 					if( checkPush ) {
@@ -304,17 +297,19 @@ class SceneEvents {
 				case EOut:
 					// leave window
 					isOut = true;
-					var i = overList.length - 1;
-					while ( i >= 0 ) {
-						onOut.cancel = false;
-						overList[i].handleEvent(onOut);
-						if ( !onOut.cancel ) {
-							overList.remove(overList[i]);
-							continue;
+					if ( overList.length > 0 ) {
+						var i = overList.length - 1;
+						while ( i >= 0 ) {
+							onOut.cancel = false;
+							overList[i].handleEvent(onOut);
+							if ( !onOut.cancel ) {
+								overList.remove(overList[i]);
+								continue;
+							}
+							i--;
 						}
-						i--;
+						selectCursor();
 					}
-					selectCursor();
 					continue;
 				default:
 				}

--- a/hxd/SceneEvents.hx
+++ b/hxd/SceneEvents.hx
@@ -63,12 +63,8 @@ class SceneEvents {
 	function onRemove(i) {
 		if( i == currentFocus )
 			currentFocus = null;
-		if ( overList.remove(i) ) {
-			if ( overList.length == 0 )
-				hxd.System.setCursor(Default);
-			else 
-				hxd.System.setCursor(overList[0].cursor);
-		}
+		if ( overList.remove(i) )
+			selectCursor();
 		pushList.remove(i);
 	}
 
@@ -125,7 +121,7 @@ class SceneEvents {
 	function emitEvent( event : hxd.Event ) {
 		var oldX = event.relX, oldY = event.relY;
 		var handled = false;
-		var checkOver = false, fillOver = false, checkPush = false, cancelFocus = false;
+		var checkOver = false, fillOver = false, checkPush = false, cancelFocus = false, updateCursor = false;
 		var overIndex : Int = 0;
 		switch( event.kind ) {
 		case EMove, ECheck:
@@ -169,6 +165,7 @@ class SceneEvents {
 								overList.insert(overIndex, i);
 								overIndex++;
 								fillOver = event.propagate;
+								updateCursor = true;
 							}
 							event.kind = oldKind;
 							event.propagate = oldPropagate;
@@ -181,12 +178,14 @@ class SceneEvents {
 									idx++;
 								} while ( idx < overIndex );
 								overList[overIndex] = o;
+								updateCursor = true;
 							} else if ( idx > overIndex ) {
 								do {
 									overList[idx] = overList[idx - 1];
 									idx--;
 								} while ( idx > overIndex );
 								overList[overIndex] = o;
+								updateCursor = true;
 							}
 							fillOver = i.propagateEvents;
 							overIndex++;
@@ -239,10 +238,10 @@ class SceneEvents {
 				}
 				idx--;
 			} while ( idx > overIndex );
-			if ( overList.length > 0 ) {
-				hxd.System.setCursor(overList[0].cursor);
-			}
+			updateCursor = true;
 		}
+		if ( updateCursor )
+			selectCursor();
 
 		if( !handled && event != checkPos ) {
 			if( event.kind == EPush )
@@ -301,6 +300,7 @@ class SceneEvents {
 					}
 				case EOver:
 					isOut = false;
+					selectCursor();
 					continue;
 				case EOut:
 					// leave window
@@ -315,6 +315,7 @@ class SceneEvents {
 						}
 						i--;
 					}
+					selectCursor();
 					continue;
 				default:
 				}
@@ -363,6 +364,21 @@ class SceneEvents {
 
 	public function getFocus() {
 		return currentFocus;
+	}
+
+	public function updateCursor( i : Interactive ) {
+		if ( overList.indexOf(i) != -1 ) selectCursor();
+	}
+
+	function selectCursor() {
+		var cur : hxd.Cursor = Default;
+		for ( o in overList ) {
+			if ( o.cursor != null ) {
+				cur = o.cursor;
+				break;
+			}
+		}
+		hxd.System.setCursor(cur);
 	}
 
 	function onEvent( e : hxd.Event ) {

--- a/hxd/SceneEvents.hx
+++ b/hxd/SceneEvents.hx
@@ -158,30 +158,8 @@ class SceneEvents {
 
 				if( checkOver ) {
 					if ( fillOver ) {
-						var idx = 0;
-						while ( idx < overList.length ) {
-							var o = overList[idx];
-							if ( o == i ) {
-								if ( idx < overIndex ) {
-									do {
-										overList[idx] = overList[idx + 1];
-										idx++;
-									} while ( idx < overIndex );
-									overList[overIndex] = o;
-								} else if ( idx > overIndex ) {
-									do {
-										overList[idx] = overList[idx - 1];
-										idx--;
-									} while ( idx > overIndex );
-									overList[overIndex] = o;
-								}
-								handled = true;
-								fillOver = i.propagateEvents;
-								break;
-							}
-							idx++;
-						}
-						if ( !handled ) {
+						var idx = overList.indexOf(i);
+						if ( idx == -1 ) {
 							var oldPropagate = event.propagate;
 							var oldKind = event.kind;
 							event.kind = EOver;
@@ -196,8 +174,29 @@ class SceneEvents {
 							event.propagate = oldPropagate;
 							event.cancel = false;
 						} else {
-							handled = false;
+							var o = overList[idx];
+							if ( idx < overIndex ) {
+								do {
+									overList[idx] = overList[idx + 1];
+									idx++;
+								} while ( idx < overIndex );
+								overList[overIndex] = o;
+							} else if ( idx > overIndex ) {
+								do {
+									overList[idx] = overList[idx - 1];
+									idx--;
+								} while ( idx > overIndex );
+								overList[overIndex] = o;
+							}
+							fillOver = i.propagateEvents;
 							overIndex++;
+						}
+						var idx = 0;
+						while ( idx < overList.length ) {
+							var o = overList[idx];
+							if ( o == i ) {
+							}
+							idx++;
 						}
 					}
 				} else {
@@ -229,20 +228,19 @@ class SceneEvents {
 		if( cancelFocus && currentFocus != null )
 			blur();
 
-		if( checkOver ) {
-			if ( overIndex < overList.length ) {
-				do {
-					onOut.cancel = false;
-					overList[overIndex].handleEvent(onOut);
-					if ( !onOut.cancel ) {
-						overList.remove(overList[overIndex]);
-						continue;
-					}
-					overIndex++;
-				} while ( overIndex < overList.length );
-				if ( overList.length > 0 ) {
-					hxd.System.setCursor(overList[0].cursor);
+		if( checkOver && overIndex < overList.length ) {
+			var idx = overList.length - 1;
+			do {
+				onOut.cancel = false;
+				overList[idx].handleEvent(onOut);
+				if ( !onOut.cancel ) {
+					overList.remove(overList[idx]);
+					continue;
 				}
+				idx--;
+			} while ( idx > overIndex );
+			if ( overList.length > 0 ) {
+				hxd.System.setCursor(overList[0].cursor);
 			}
 		}
 
@@ -307,15 +305,15 @@ class SceneEvents {
 				case EOut:
 					// leave window
 					isOut = true;
-					var i = 0;
-					while ( i < overList.length ) {
+					var i = overList.length - 1;
+					while ( i >= 0 ) {
 						onOut.cancel = false;
 						overList[i].handleEvent(onOut);
 						if ( !onOut.cancel ) {
 							overList.remove(overList[i]);
 							continue;
 						}
-						i++;
+						i--;
 					}
 					continue;
 				default:

--- a/hxd/SceneEvents.hx
+++ b/hxd/SceneEvents.hx
@@ -302,10 +302,8 @@ class SceneEvents {
 						while ( i >= 0 ) {
 							onOut.cancel = false;
 							overList[i].handleEvent(onOut);
-							if ( !onOut.cancel ) {
+							if ( !onOut.cancel )
 								overList.remove(overList[i]);
-								continue;
-							}
 							i--;
 						}
 						selectCursor();


### PR DESCRIPTION
* `currentOver` was replaced by `overList`
* `EOut` events no longer reset `mouseDownButton`, as it prevents firing of `onReleaseOutside`.
* `Interactive` interface expanded to expose `cursor` and `propagateEvents`. Used to properly set cursor when over list changes and do propagation checks.

resolve #209