### PR TITLE
Add liveupdate support to Sound

### DIFF
--- a/hxd/res/Sound.hx
+++ b/hxd/res/Sound.hx
@@ -90,24 +90,8 @@ class Sound extends Resource {
 			if (old.channels != data.channels || old.samples != data.samples || old.sampleFormat != data.sampleFormat || old.samplingRate != data.samplingRate) {
 				var manager = hxd.snd.Manager.get();
 				for ( ch in manager.getAll(this) ) {
-					// Attempt to restart sound
-					var beff = ch.bindedEffects.copy();
-					var eff = ch.effects.copy();
-					var fade = ch.currentFade;
-					ch.stop();
-					var nch = manager.play(this, ch.channelGroup, ch.soundGroup);
-					nch.loop = ch.loop;
-					nch.currentFade = fade;
-					nch.currentVolume = ch.currentVolume;
-					nch.effects = eff;
-					nch.bindedEffects = beff;
-					nch.audibleGain = ch.audibleGain;
-					nch.pause = ch.pause;
-					nch.mute = ch.mute;
-					nch.priority = ch.priority;
-					nch.queue = ch.queue;
-					nch.position = ch.position;
-					
+					ch.duration = data.duration;
+					ch.position = ch.position;
 				}
 			}
 		}

--- a/hxd/res/Sound.hx
+++ b/hxd/res/Sound.hx
@@ -8,6 +8,8 @@ enum SoundFormat {
 
 class Sound extends Resource {
 
+	static var ENABLE_AUTO_WATCH = true;
+
 	var data : hxd.snd.Data;
 	var channel : hxd.snd.Channel;
 	public var lastPlay(default, null) = 0.;
@@ -50,6 +52,8 @@ class Sound extends Resource {
 		}
 		if( data == null )
 			throw "Unsupported sound format " + entry.path;
+		if ( ENABLE_AUTO_WATCH )
+			watch(watchCallb);
 		return data;
 	}
 
@@ -75,6 +79,38 @@ class Sound extends Resource {
 
 	public static function startWorker() {
 		return false;
+	}
+
+	@:access(hxd.snd.ChannelBase)
+	function watchCallb() {
+		var old = this.data;
+		this.data = null;
+		var data = getData();
+		if (old != null) {
+			if (old.channels != data.channels || old.samples != data.samples || old.sampleFormat != data.sampleFormat || old.samplingRate != data.samplingRate) {
+				var manager = hxd.snd.Manager.get();
+				for ( ch in manager.getAll(this) ) {
+					// Attempt to restart sound
+					var beff = ch.bindedEffects.copy();
+					var eff = ch.effects.copy();
+					var fade = ch.currentFade;
+					ch.stop();
+					var nch = manager.play(this, ch.channelGroup, ch.soundGroup);
+					nch.loop = ch.loop;
+					nch.currentFade = fade;
+					nch.currentVolume = ch.currentVolume;
+					nch.effects = eff;
+					nch.bindedEffects = beff;
+					nch.audibleGain = ch.audibleGain;
+					nch.pause = ch.pause;
+					nch.mute = ch.mute;
+					nch.priority = ch.priority;
+					nch.queue = ch.queue;
+					nch.position = ch.position;
+					
+				}
+			}
+		}
 	}
 
 }

--- a/hxd/snd/Channel.hx
+++ b/hxd/snd/Channel.hx
@@ -46,6 +46,8 @@ class Channel extends ChannelBase {
 	function set_position(v : Float) {
 		lastStamp = haxe.Timer.stamp();
 		positionChanged = true;
+		if (v > duration) v = duration;
+		else if (v < 0) v = 0;
 		return position = v;
 	}
 

--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -154,7 +154,7 @@ class Manager {
 	**/
 	public function getAll( sound : hxd.res.Sound ) : Iterator<Channel> {
 		var ch = channels;
-		var result = new Array<Channel>;
+		var result = new Array<Channel>();
 		while ( ch != null ) {
 			if ( ch.sound == sound )
 				result.push(ch);

--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -149,6 +149,20 @@ class Manager {
 			channels.stop();
 	}
 
+	/**
+		Returns iterator with all active instances of a Sound at the call time.
+	**/
+	public function getAll( sound : hxd.res.Sound ) : Iterator<Channel> {
+		var ch = channels;
+		var result = new Array<Channel>;
+		while ( ch != null ) {
+			if ( ch.sound == sound )
+				result.push(ch);
+			ch = ch.next;
+		}
+		return new hxd.impl.ArrayIterator(result);
+	}
+
 	public function cleanCache() {
 		for (k in soundBufferMap.keys()) {
 			var b = soundBufferMap.get(k);


### PR DESCRIPTION
* Sound now support `LIVE_UPDATE`.
* `hxd.snd.Manager` now have `getAll( sound : hxd.res.Sound )` which would return iterator of all currently active channels of specified Sound.
* Added safeguard to `Channel.position` to avoid out-of-bounds position and undefined behavior when trying to buffer sound data. Should it wrap around if `loop == true`?