### PR TITLE
Making sure input material is set

### DIFF
--- a/h3d/parts/GpuParticles.hx
+++ b/h3d/parts/GpuParticles.hx
@@ -548,14 +548,12 @@ class GpuParticles extends h3d.scene.MultiMaterial {
 			material.mainPass.culling = None;
 			material.mainPass.depthWrite = false;
 			material.blendMode = Alpha;
-			if( this.material == null ) this.material = material;
 			if( g.material != null ) {
 				material.props = g.getMaterialProps();
 				material.name = g.name;
 			}
-		} else {
-			this.material = material;
 		}
+		if( this.material == null ) this.material = material;
 		material.mainPass.addShader(g.pshader);
 		if( index == null )
 			index = groups.length;

--- a/h3d/parts/GpuParticles.hx
+++ b/h3d/parts/GpuParticles.hx
@@ -553,6 +553,8 @@ class GpuParticles extends h3d.scene.MultiMaterial {
 				material.props = g.getMaterialProps();
 				material.name = g.name;
 			}
+		} else {
+			this.material = material;
 		}
 		material.mainPass.addShader(g.pshader);
 		if( index == null )


### PR DESCRIPTION
During development with GpuParticles we realized addGroup() didn't accept custom material passed and this was needed for having Additive blending. 