### PR TITLE
Implement GLES3+ and HXSL texelFetch

### DIFF
--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -202,6 +202,8 @@ enum TGlobal {
 	//All;
 	Texture;
 	TextureLod;
+	Texel;
+	TexelLod;
 	// ...other texture* operations
 	// constructors
 	ToInt;
@@ -235,6 +237,8 @@ enum TGlobal {
 	// debug / internal
 	ChannelRead;
 	ChannelReadLod;
+	ChannelFetch;
+	ChannelFetchLod;
 	Trace;
 	// instancing
 	VertexID;

--- a/hxsl/Dce.hx
+++ b/hxsl/Dce.hx
@@ -232,6 +232,12 @@ class Dce {
 		case TCall({ e : TGlobal(ChannelReadLod) }, [_, uv, lod, { e : TConst(CInt(cid)) }]):
 			var c = channelVars[cid];
 			return { e : TCall({ e : TGlobal(TextureLod), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(uv,true), mapExpr(lod,true)]), t : TVoid, p : e.p };
+		case TCall({ e : TGlobal(ChannelFetch) }, [_, pos, { e : TConst(CInt(cid)) }]):
+			var c = channelVars[cid];
+			return { e : TCall({ e : TGlobal(Texel), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(pos,true)]), t : TVoid, p : e.p };
+		case TCall({ e : TGlobal(ChannelFetchLod) }, [_, pos, lod, { e : TConst(CInt(cid)) }]):
+			var c = channelVars[cid];
+			return { e : TCall({ e : TGlobal(Texel), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(pos,true), mapExpr(lod,true)]), t : TVoid, p : e.p };
 		case TIf(e, econd, eelse):
 			var e = mapExpr(e, true);
 			var econd = mapExpr(econd, isVar);

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -27,6 +27,12 @@ class GlslOut {
 		m.set(Mat3x4, "_mat3x4");
 		m.set(VertexID, "gl_VertexID");
 		m.set(InstanceID, "gl_InstanceID");
+		m.set(IVec2, "ivec2");
+		m.set(IVec3, "ivec3");
+		m.set(IVec4, "ivec4");
+		m.set(BVec2, "bvec2");
+		m.set(BVec3, "bvec3");
+		m.set(BVec4, "bvec4");
 		for( g in m )
 			KWDS.set(g, true);
 		m;
@@ -246,6 +252,12 @@ class GlslOut {
 				return "textureCubeLodEXT";
 			default:
 			}
+		case Texel, TexelLod:
+			// if ( isES2 )
+			// 	decl("vec4 _texelFetch(sampler2d tex, ivec2 pos, int lod) ...")
+			// 	return "_texelFetch";
+			// else
+				return "texelFetch";
 		case Mod if( rt == TInt && isES ):
 			decl("int _imod( int x, int y ) { return int(mod(float(x),float(y))); }");
 			return "_imod";
@@ -366,6 +378,14 @@ class GlslOut {
 			add("clamp(");
 			addValue(e, tabs);
 			add(", 0., 1.)");
+		case TCall({ e : TGlobal(g = Texel) }, args):
+			add(getFunName(g,args,e.t));
+			add("(");
+			for( e in args ) {
+				addValue(e, tabs);
+				add(", ");
+			}
+			add("0)");
 		case TCall(v, args):
 			switch( v.e ) {
 			case TGlobal(g):

--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -27,6 +27,12 @@ class HlslOut {
 		m.set(Inversesqrt, "rsqrt");
 		m.set(VertexID,"_in.vertexID");
 		m.set(InstanceID,"_in.instanceID");
+		m.set(IVec2, "int2");
+		m.set(IVec3, "int3");
+		m.set(IVec4, "int3");
+		m.set(BVec2, "bool2");
+		m.set(BVec3, "bool3");
+		m.set(BVec4, "bool4");
 		for( g in m )
 			KWDS.set(g, true);
 		m;
@@ -249,6 +255,28 @@ class HlslOut {
 				addValue(args[i],tabs);
 			}
 			add(")");
+		case TCall({ e : TGlobal(g = (Texel | TexelLod)) }, args):
+			addValue(args[0], tabs);
+			add(".Load(");
+			switch ( args[1].t ) {
+				case TSampler2D:
+					add("int3(");
+				case TSampler2DArray:
+					add("int4(");
+				default:
+					throw "assert";
+			}
+			addValue(args[1],tabs);
+			switch( g ) {
+				case Texel:
+					add(", 0");
+				case TexelLod:
+					add(", ");
+					addValue(args[2],tabs);
+				default:
+					throw "assert";
+			}
+			add("))");
 		case TCall(e = { e : TGlobal(g) }, args):
 			switch( [g,args.length] ) {
 			case [Vec2, 1] if( args[0].t == TFloat ):


### PR DESCRIPTION
Adds `fetch` and `fetchLod` functions to `Sampler2D` and `Sampler2DArray` allowing for non-UV-based texture pixel fetching.
Additionally fixed ivec and bvec generation both for GLSL and HXSL.

I'm not sure what to do with GLES2. Throw an error saying that `texelFetch` is not available on GLES2? Emulation will require adding size uniform for each texture and I'm not sure how to implement such thing (assignment of texture also assign _size uniform. I personally would like to have at least emulated support for GLES2, as not all browsers support GLES3. 
I did not implement if for flash, because I have no clue how it works and does it even support such operation.
Resolves #549 