### PR TITLE
Add SceneEvents.defaultCursor

### DIFF
--- a/hxd/SceneEvents.hx
+++ b/hxd/SceneEvents.hx
@@ -45,6 +45,11 @@ class SceneEvents {
 	 */
 	public var mouseCheckMove = true;
 
+	/**
+	 * Default cursor when there is no Interactive present under cursor.
+	 */
+	public var defaultCursor : Cursor = Default;
+
 	public function new( ?window ) {
 		scenes = [];
 		pendingEvents = [];
@@ -363,7 +368,7 @@ class SceneEvents {
 	}
 
 	function selectCursor() {
-		var cur : hxd.Cursor = Default;
+		var cur : hxd.Cursor = defaultCursor;
 		for ( o in overList ) {
 			if ( o.cursor != null ) {
 				cur = o.cursor;

--- a/hxd/System.hx
+++ b/hxd/System.hx
@@ -52,6 +52,11 @@ class System {
 	public static function start( callb : Void -> Void ) : Void {
 	}
 
+	/**
+		Sets currently shown cursor.
+		This method designated to be used by custom `hxd.System.setCursor`.
+		Calling it outside of atuomated Interactive cursor update system leads to undefined behavior, and not adviced.
+	**/
 	public static function setNativeCursor( c : Cursor ) : Void {
 	}
 

--- a/hxd/System.hx
+++ b/hxd/System.hx
@@ -54,8 +54,8 @@ class System {
 
 	/**
 		Sets currently shown cursor.
-		This method designated to be used by custom `hxd.System.setCursor`.
-		Calling it outside of atuomated Interactive cursor update system leads to undefined behavior, and not adviced.
+		This method is designated to be used by custom `hxd.System.setCursor`.
+		Calling it outside of automated Interactive cursor update system leads to undefined behavior, and not advised.
 	**/
 	public static function setNativeCursor( c : Cursor ) : Void {
 	}


### PR DESCRIPTION
Also docs for System.setNativeCursor to clarify it's usage.
Partially resolves #582 
Should there be wiki doc to clarify how to utilize cursor system? 
In general, I thinking about making separate "Community notes" section that will be much more chaotic (code snippets, samples, gists, etc, as name suggests - notes) and faster to produce and not a detailed thought-out doc pages, but they would cover some things community seem to have difficulties with. Lack of documentation is biggest issue people have, and not a lot of people willing to spend a lot of time (including me) to write proper documentation.