### PR TITLE
Implement 2D Scene ScaleMode

### DIFF
--- a/samples/ScaleMode2D.hx
+++ b/samples/ScaleMode2D.hx
@@ -1,0 +1,77 @@
+import hxd.Key;
+import h2d.Scene;
+
+class ScaleMode2D extends SampleApp {
+
+	override function init()
+	{
+
+		var bg = new h2d.Bitmap(h2d.Tile.fromColor(0x333333), s2d);
+		var minBg = new h2d.Bitmap(h2d.Tile.fromColor(0x222222), s2d);
+
+		super.init();
+
+		var mode:Int = 0;
+		// Width and height used in Stretch, LetterBox, Fixed and AutoZoom
+		var width:Int = 320;
+		var height:Int = 240;
+		// Zoom used in Fixed and Zoom
+		var zoom:Float = 1;
+		// Integer Scale used in LetterBox and AutoZoom
+		var intScale:Bool = false;
+		// Vertical and Horizontal Align used in LetterBox and Fixed.
+		var halign:ScaleModeAlign = Center;
+		var valign:ScaleModeAlign = Center;
+
+		var sceneInfo:h2d.Text;
+
+		function setMode()
+		{
+			switch ( mode ) {
+				case 0:
+					s2d.scaleMode = Resize;
+				case 1:
+					s2d.scaleMode = Stretch(width, height);
+				case 2:
+					s2d.scaleMode = LetterBox(width, height, intScale, halign, valign);
+				case 3:
+					s2d.scaleMode = Fixed(width, height, zoom, valign, halign);
+				case 4:
+					s2d.scaleMode = Zoom(zoom);
+				case 5:
+					s2d.scaleMode = AutoZoom(width, height, intScale);
+			}
+			minBg.scaleX = width;
+			minBg.scaleY = height;
+			bg.scaleX = s2d.width;
+			bg.scaleY = s2d.height;
+			sceneInfo.text = "Scene size: " + s2d.width + "x" + s2d.height;
+		}
+
+		addText("Press R to set ScaleMode to Resize");
+		addChoice("ScaleMode", ScaleMode.getConstructors(), function(idx) { mode = idx; }, 0);
+		addSlider("width", function() { return width; }, function(v) { width = Std.int(v); }, 0, 800);
+		addSlider("height", function() { return height; }, function(v) { height = Std.int(v); }, 0, 600);
+		addSlider("zoom", function() { return zoom; }, function(v) { zoom = v; }, 0.01, 5);
+		addCheck("integerScale", function() { return intScale; }, function(v) { intScale = v; });
+		addChoice("HAlign", ["Left", "Center", "Right"], function(v) { halign = [Left, Center, Right][v]; }, 1 );
+		addChoice("VAlign", ["Top", "Center", "Bottom"], function(v) { valign = [Top, Center, Bottom][v]; }, 1 );
+		addButton("Apply", setMode);
+		sceneInfo = addText("");
+		addText("Light-grey: Actual Scene width and height");
+		addText("Dark-grey: Parameter-specified width and height");
+
+		setMode();
+	}
+
+	override function update(dt:Float)
+	{
+		if (Key.isReleased(Key.R)) s2d.scaleMode = Resize;
+	}
+
+	static function main() {
+		hxd.Res.initEmbed();
+		new ScaleMode2D();
+	}
+
+}


### PR DESCRIPTION
* Closes #524, closes #563.
* Implements 8 different scaling modes for `s2d.Scene`.
* Deprecates `zoom`. Now can be done with `ScaleMode.Zoom(v)`
* Deprecates `setFixedSize`. Now can be done with `ScaleMode.Stretch(w, h)`.
* Removes size checks each frame and instead hooks to window resize events.

Now onto modes:
* `Fill` - it's the default and just resizes Scene to fill engine size.
* `Stretch` - basically good old ugly `setFixedSize`.
* `KeepAspect` - scales Scene with preservation of aspect-ratio. Can anchor on top-left and center.
* `KeepPixelSize` - same as above, but uses integer scaling to ensure square pixels.
* `Exact` - just forces width/height/zoom/centering disregarding adaptation.
* `Zoom` - Same as old `zoom` variable.
* `EnsureArea` - works same as KeepAspect, but instead of having fixed width and height - adaptas it to fill the screen. For example window 800x600 and `EnsureArea(400, 250)` would be upscaled to 2x and cover 800x500, but `height` will be `600`.
* `EnsurePixelArea` - same as above but integer scaling.

There is a particular issue with `drawTile` however - it checks for Scene bounds, not "is it visible on screen". It's logical but may be unexpected for some. We may keep it as is (`scaleMode` docs mention this behavior), force-clip Scene during rendering (`setRenderZone`) or rework how clipper in `drawTile` operates to check window-bounds instead of Scene bounds.