### PR TITLE
Convert: Use full extension chain

### DIFF
--- a/hxd/fs/FileEntry.hx
+++ b/hxd/fs/FileEntry.hx
@@ -5,7 +5,15 @@ class FileEntry {
 	public var name(default, null) : String;
 	public var path(get, never) : String;
 	public var directory(get, never) : String;
+	/**
+		Real extension of file referenced by FileEntry in lowercase.
+	**/
 	public var extension(get, never) : String;
+	/**
+		Full extension chain of file referenced by FileEntry in lowercase.  
+		For `file.extra.ext` it will return full extension chain - `extra.ext` while `extension` property will return only `ext`.
+	**/
+	public var fullExtension(get, never) : String;
 	public var size(get, never) : Int;
 	public var isDirectory(get, never) : Bool;
 	public var isAvailable(get, never) : Bool;
@@ -37,13 +45,17 @@ class FileEntry {
 	function get_path() : String { throw "path() not implemented"; return null; };
 
 	function get_directory() {
-		var p = path.split("/");
-		p.pop();
-		return p.join("/");
+		var idx = path.lastIndexOf("/");
+		return idx == -1 ? "" : path.substr(0, idx);
 	}
 
 	function get_extension() {
-		var np = name.split(".");
-		return np.length == 1 ? "" : np.pop().toLowerCase();
+		var idx = name.lastIndexOf(".");
+		return idx == -1 ? "" : name.substr(idx+1).toLowerCase();
+	}
+
+	function get_fullExtension() {
+		var idx = name.indexOf(".");
+		return idx == -1 ? "" : name.substr(idx+1).toLowerCase();
 	}
 }

--- a/hxd/fs/LocalFileSystem.hx
+++ b/hxd/fs/LocalFileSystem.hx
@@ -460,8 +460,12 @@ class LocalFileSystem implements FileSystem {
 	}
 
 	function convert( e : LocalEntry ) {
-		var ext = e.extension;
+		var ext = e.fullExtension;
 		var conv = converts.get(ext);
+		if ( conv == null ) {
+			ext = e.extension;
+			conv = converts.get(ext);
+		}
 		if( conv == null )
 			return;
 		if (e.convertedFile == null) {


### PR DESCRIPTION
Closes #607 
* Added `FileEntry.fullExtension` property
* Converts now allow to use extension chains, making it consistent between Resource and Convert.
* Also made `FileEntry.directory` and `FileEntry.extension` to use `indexOf` instead of allocating an array. It hurt my eyes when I've seen this. :)

Now there's another inconsistency btw: `Resource` does not check for real extension, only extension chain while `Convert` does both.