### PR TITLE
Add type to App.loadAssets onLoaded argument

### DIFF
--- a/hxd/App.hx
+++ b/hxd/App.hx
@@ -148,7 +148,7 @@ class App implements h3d.IDrawable {
 		                method when loading is complete
 	**/
 	@:dox(show)
-	function loadAssets( onLoaded ) {
+	function loadAssets( onLoaded : Void->Void ) {
 		onLoaded();
 	}
 


### PR DESCRIPTION
Fix vscode `override` completion generating `onLoaded:() -> ?` (which is invalid syntax caused by plugin/completion server not being sure what that function returns).
Also newline because Github build-in editor is "smart". :)