### PR TITLE
Fix JS target after HaxeFoundation/Haxe#8422

### DIFF
--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -1151,7 +1151,7 @@ class GlDriver extends Driver {
 			gl.texImage2D(face, mipLevel, t.t.internalFmt, pixels.width, pixels.height, 0, getChannels(t.t), t.t.pixelFmt, stream);
 		#elseif js
 		var bufLen = pixels.stride * pixels.height;
-		var buffer = switch( t.format ) {
+		var buffer : ArrayBufferView = switch( t.format ) {
 		case RGBA32F, R32F, RG32F, RGB32F: new Float32Array(@:privateAccess pixels.bytes.b.buffer, pixels.offset, bufLen>>2);
 		case RGBA16F, R16F, RG16F, RGB16F: new Uint16Array(@:privateAccess pixels.bytes.b.buffer, pixels.offset, bufLen>>1);
 		case RGB10A2, RG11B10UF: new Uint32Array(@:privateAccess pixels.bytes.b.buffer, pixels.offset, bufLen>>2);


### PR DESCRIPTION
HaxeFoundation/Haxe#8422 changed that TypedArrays are no longer compatible with each other directly via `interface`, so there is now a need for implicit declaration that it is indeed an ArrayBufferView. Fixes JS compilation/completion server being unhappy.
P.S. Trusting compiler in figuring out variable type is not always the best decision. ;)