### PR TITLE
Fix domkit (v2?) demo for js

### DIFF
--- a/h2d/domkit/Style.hx
+++ b/h2d/domkit/Style.hx
@@ -13,8 +13,10 @@ class Style extends domkit.CssStyle {
 
 	public function load( r : hxd.res.Resource ) {
 		r.watch(function() {
+			#if (sys || nodejs)
 			var fs = hxd.impl.Api.downcast(hxd.res.Loader.currentInstance.fs, hxd.fs.LocalFileSystem);
 			if( fs != null ) fs.clearCache();
+			#end
 			onChange();
 		});
 		resources.push(r);

--- a/samples/Domkit.hx
+++ b/samples/Domkit.hx
@@ -44,7 +44,7 @@ class Domkit extends hxd.App {
 
 		var style = new h2d.domkit.Style();
 		style.load(hxd.Res.style);
-		style.applyTo(view);
+		view.dom.applyStyle(style);
 	}
 
 	override function onResize() {


### PR DESCRIPTION
I was trying to get started on heaps + domkit but the demo wouldn't work.
I had to do [domkit#9](https://github.com/HeapsIO/domkit/pull/9) too to make it work.
Note: I was using heaps `7a216be` and domkit `195fa25` (both latest at the time)

I'm not sure about `#if (sys || nodejs)`, maybe it should be handled differently?