### PR TITLE
fix: flickering due to incorrect timing of clear. adding optional pre…

### DIFF
--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -644,7 +644,7 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 	}
 
 	function drawImplTo(s:Object, t:h3d.mat.Texture) {
-		if (!t.flags.has(Target))
+		if( !t.flags.has(Target) )
 			throw "Can only draw to texture created with Target flag";
 		var needClear = !t.flags.has(WasCleared);
 		ctx.engine = h3d.Engine.getCurrent();
@@ -652,7 +652,7 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 		ctx.globalAlpha = alpha;
 		ctx.begin();
 		ctx.pushTarget(t);
-		if (needClear)
+		if( needClear )
 			ctx.engine.clear(0);
 		s.drawRec(ctx);
 		ctx.popTarget();

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -643,16 +643,16 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 		ctx.elapsedTime = v;
 	}
 
-	function drawImplTo( s : Object, t : h3d.mat.Texture ) {
-
-		if( !t.flags.has(Target) ) throw "Can only draw to texture created with Target flag";
+	function drawImplTo(s:Object, t:h3d.mat.Texture) {
+		if (!t.flags.has(Target))
+			throw "Can only draw to texture created with Target flag";
 		var needClear = !t.flags.has(WasCleared);
 		ctx.engine = h3d.Engine.getCurrent();
-		ctx.engine.begin();
+		ctx.engine.begin(true);
 		ctx.globalAlpha = alpha;
 		ctx.begin();
 		ctx.pushTarget(t);
-		if( needClear )
+		if (needClear)
 			ctx.engine.clear(0);
 		s.drawRec(ctx);
 		ctx.popTarget();

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -644,8 +644,7 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 	}
 
 	function drawImplTo( s : Object, t : h3d.mat.Texture ) {
-		if( !t.flags.has(Target) )
-			throw "Can only draw to texture created with Target flag";
+		if( !t.flags.has(Target) ) throw "Can only draw to texture created with Target flag";
 		var needClear = !t.flags.has(WasCleared);
 		ctx.engine = h3d.Engine.getCurrent();
 		ctx.engine.begin(true);

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -643,7 +643,7 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 		ctx.elapsedTime = v;
 	}
 
-	function drawImplTo(s:Object, t:h3d.mat.Texture) {
+	function drawImplTo( s : Object, t : h3d.mat.Texture ) {
 		if( !t.flags.has(Target) )
 			throw "Can only draw to texture created with Target flag";
 		var needClear = !t.flags.has(WasCleared);

--- a/h3d/Engine.hx
+++ b/h3d/Engine.hx
@@ -278,7 +278,7 @@ class Engine {
 		if( !driver.isDisposed() ) driver.resize(width, height);
 	}
 
-	public function begin(preventClear = false) {
+	public function begin( preventClear = false ) {
 		if( driver.isDisposed() )
 			return false;
 		drawTriangles = 0;

--- a/h3d/Engine.hx
+++ b/h3d/Engine.hx
@@ -279,7 +279,7 @@ class Engine {
 	}
 
 	public function begin(preventClear = true) {
-		if (driver.isDisposed())
+		if( driver.isDisposed() )
 			return false;
 		drawTriangles = 0;
 		shaderSwitches = 0;
@@ -290,7 +290,7 @@ class Engine {
 		haxe.System.beginFrame();
 		#end
 		driver.begin(hxd.Timer.frameCount);
-		if (backgroundColor != null && !preventClear)
+		if( backgroundColor != null && !preventClear )
 			clear(backgroundColor, 1, 0);
 		return true;
 	}

--- a/h3d/Engine.hx
+++ b/h3d/Engine.hx
@@ -278,7 +278,7 @@ class Engine {
 		if( !driver.isDisposed() ) driver.resize(width, height);
 	}
 
-	public function begin(preventClear = true) {
+	public function begin(preventClear = false) {
 		if( driver.isDisposed() )
 			return false;
 		drawTriangles = 0;

--- a/h3d/Engine.hx
+++ b/h3d/Engine.hx
@@ -278,10 +278,9 @@ class Engine {
 		if( !driver.isDisposed() ) driver.resize(width, height);
 	}
 
-	public function begin() {
-		if( driver.isDisposed() )
+	public function begin(preventClear = true) {
+		if (driver.isDisposed())
 			return false;
-		// init
 		drawTriangles = 0;
 		shaderSwitches = 0;
 		drawCalls = 0;
@@ -291,7 +290,8 @@ class Engine {
 		haxe.System.beginFrame();
 		#end
 		driver.begin(hxd.Timer.frameCount);
-		if( backgroundColor != null ) clear(backgroundColor, 1, 0);
+		if (backgroundColor != null && !preventClear)
+			clear(backgroundColor, 1, 0);
 		return true;
 	}
 


### PR DESCRIPTION
We had an issue with the Engine.clear() being called before actually setting the target in drawImplTo().

This caused flickering on some devices because there in some cases where no targets set (therefore clearing backbuffer).

Adding an optional argument to prevent clearing to make it possible to use clearlogic properly in h2d.Scene and honor the needsClear flag.

People may start experience issue with this request because they now manually need to actually clear the WasCleared flag if they reuse a texture for drawTo every frame.