### PR TITLE
Add docs to `Key.MOUSE_WHEEL_*` variables

### DIFF
--- a/hxd/Key.hx
+++ b/hxd/Key.hx
@@ -132,7 +132,21 @@ class Key {
 	public static inline var MOUSE_MIDDLE = 2;
 	public static inline var MOUSE_BACK = 3;
 	public static inline var MOUSE_FORWARD = 4;
+	/**
+	 * Mouse wheel does not have an off signal, and should be checked only trough `isPressed` method.
+	 * Note that there may be multiple wheel scrolls between 2 frames, and to receive more accurate
+	 * results, it is recommended to directly listen to wheel events which also provide OS-generated wheel delta value.
+	 * See `Interactive.onWheel` for per-interactive events. For scene-based see `Scene.addEventListener`
+	 * when event is `EWheel`. For global hook use `Window.addEventTarget` method.
+	 */
 	public static inline var MOUSE_WHEEL_UP = 5;
+	/**
+	 * Mouse wheel does not have an off signal, and should be checked only trough `isPressed` method.
+	 * Note that there may be multiple wheel scrolls between 2 frames, and to receive more accurate
+	 * results, it is recommended to directly listen to wheel events which also provide OS-generated wheel delta value.
+	 * See `Interactive.onWheel` for per-interactive events. For scene-based see `Scene.addEventListener`
+	 * when event is `EWheel`. For global hook use `Window.addEventTarget` method.
+	 */
 	public static inline var MOUSE_WHEEL_DOWN = 6;
 
 	/** a bit that is set for left keys **/


### PR DESCRIPTION
Related: #671 
Wheel events are special case, because they only have "on" signal, and never "unpressed", sometimes confusing people when they use `Key.isDown` with them and end up with `true` each frame after first scroll.
Added documentation clarifying that wheel should only be checked via `isPressed` as well as note the shortcomings of this approach with appropriate alternatives.