### PR TITLE
Reorder EOut/EOver events

### DIFF
--- a/h2d/Interactive.hx
+++ b/h2d/Interactive.hx
@@ -249,11 +249,17 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 		return scene != null && scene.events != null && @:privateAccess scene.events.currentFocus == this;
 	}
 
-	/** Sent when mouse enters Interactive hitbox area. **/
+	/**
+		Sent when mouse enters Interactive hitbox area.
+		`event.propagate` and `event.cancel` are ignored during `onOver`.
+		Propagation can be set with `onMove` event, as well as cancelling `onMove` will prevent `onOver`.
+	**/
 	public dynamic function onOver( e : hxd.Event ) {
 	}
 
-	/** Sent when mouse exits Interactive hitbox area. **/
+	/** Sent when mouse exits Interactive hitbox area.
+		`event.propagate` and `event.cancel` are ignored during `onOut`.
+	**/
 	public dynamic function onOut( e : hxd.Event ) {
 	}
 

--- a/h3d/scene/Interactive.hx
+++ b/h3d/scene/Interactive.hx
@@ -138,11 +138,17 @@ class Interactive extends Object implements hxd.SceneEvents.Interactive {
 		return scene != null && scene.events != null && @:privateAccess scene.events.currentFocus == this;
 	}
 
-	/** Sent when mouse enters Interactive hitbox area. **/
+	/**
+		Sent when mouse enters Interactive hitbox area.
+		`event.propagate` and `event.cancel` are ignored during `onOver`.
+		Propagation can be set with `onMove` event, as well as cancelling `onMove` will prevent `onOver`.
+	**/
 	public dynamic function onOver( e : hxd.Event ) {
 	}
 
-	/** Sent when mouse exits Interactive hitbox area. **/
+	/** Sent when mouse exits Interactive hitbox area.
+		`event.propagate` and `event.cancel` are ignored during `onOut`.
+	**/
 	public dynamic function onOut( e : hxd.Event ) {
 	}
 

--- a/hxd/SceneEvents.hx
+++ b/hxd/SceneEvents.hx
@@ -21,6 +21,9 @@ class SceneEvents {
 	var scenes : Array<InteractiveScene>;
 
 	var overList : Array<Interactive>;
+	// Indexes and rel position in overList of Interactives that received EOver this frame.
+	// This array is never cleared apart from nulling Interactive, because internal counter is used, so those values are meaningless on practice.
+	var overCandidates : Array<{ i : Interactive, x : Float, y : Float, z : Float }>;
 	var overIndex : Int = -1;
 	var outIndex : Int = -1;
 	var currentFocus : Interactive;
@@ -35,6 +38,7 @@ class SceneEvents {
 	var focusLost = new hxd.Event(EFocusLost);
 	var checkPos = new hxd.Event(ECheck);
 	var onOut = new hxd.Event(EOut);
+	var onOver = new hxd.Event(EOver);
 	var isOut = false;
 
 	/**
@@ -57,6 +61,7 @@ class SceneEvents {
 		pendingEvents = [];
 		pushList = [];
 		overList = [];
+		overCandidates = [];
 		if( window == null ) window = hxd.Window.getInstance();
 		this.window = window;
 		window.addEventTarget(onEvent);
@@ -136,7 +141,7 @@ class SceneEvents {
 	}
 
 	function emitEvent( event : hxd.Event ) {
-		var oldX = event.relX, oldY = event.relY;
+		var oldX = event.relX, oldY = event.relY, overCandidateCount = 0;
 		var handled = false;
 		var checkOver = false, fillOver = false, checkPush = false, cancelFocus = false, updateCursor = false;
 		overIndex = 0;
@@ -173,20 +178,23 @@ class SceneEvents {
 					if ( fillOver ) {
 						var idx = overList.indexOf(i);
 						if ( idx == -1 ) {
-							var oldPropagate = event.propagate;
-							var oldKind = event.kind;
-							event.kind = EOver;
-							event.cancel = false;
-							i.handleEvent(event);
-							if ( !event.cancel ) {
-								overList.insert(overIndex, i);
-								overIndex++;
-								fillOver = event.propagate;
-								updateCursor = true;
+							if ( overCandidates.length == overCandidateCount ) {
+								overCandidates[overCandidateCount] = {
+									i : i,
+									x : event.relX,
+									y : event.relY,
+									z : event.relZ
+								};
+							} else {
+								var info = overCandidates[overCandidateCount];
+								info.i = i;
+								info.x = event.relX;
+								info.y = event.relY;
+								info.z = event.relZ;
 							}
-							event.kind = oldKind;
-							event.propagate = oldPropagate;
-							event.cancel = false;
+							overCandidateCount++;
+							overList.insert(overIndex++, i);
+							updateCursor = true;
 						} else {
 							if ( idx < overIndex ) {
 								do {
@@ -203,9 +211,9 @@ class SceneEvents {
 								overList[overIndex] = i;
 								updateCursor = true;
 							}
-							fillOver = i.propagateEvents;
 							overIndex++;
 						}
+						fillOver = event.propagate;
 					}
 				} else {
 					if( checkPush ) {
@@ -236,17 +244,26 @@ class SceneEvents {
 		if( cancelFocus && currentFocus != null )
 			blur();
 
-		if( checkOver && overIndex < overList.length ) {
-			outIndex = overList.length - 1;
-			do {
-				onOut.cancel = false;
-				overList[outIndex].handleEvent(onOut);
-				if ( !onOut.cancel ) {
+		if ( checkOver ) {
+			if ( overIndex < overList.length ) {
+				outIndex = overList.length - 1;
+				do {
+					overList[outIndex].handleEvent(onOut);
 					overList.remove(overList[outIndex]);
-					continue;
-				}
-			} while ( --outIndex >= overIndex );
-			updateCursor = true;
+				} while ( --outIndex >= overIndex );
+				updateCursor = true;
+			}
+			if ( overCandidateCount != 0 ) {
+				var i = 0, ev = onOver;
+				do {
+					var info = overCandidates[i++];
+					ev.relX = info.x;
+					ev.relY = info.y;
+					ev.relZ = info.z;
+					info.i.handleEvent(ev);
+					info.i = null;
+				} while ( i < overCandidateCount );
+			}
 		}
 		overIndex = -1;
 


### PR DESCRIPTION
Resolve #675; Resolve #566
* Ensure EOver is called after EOut
* Remove ability to cancel EOver/EOut
* Update docs for onOver/onOut

For backward compatibility - rel values of Event are retained in case they used during EOver. I'm not sure if `relZ` should be retained. I have a feeling that docs are a bit lacking still in clarifying of EOver/EOut special case.