### PR TITLE
Added windowFixed macro to disable window resizing.

### DIFF
--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -87,6 +87,7 @@ class System {
 		var height = 600;
 		var size = haxe.macro.Compiler.getDefine("windowSize");
 		var title = haxe.macro.Compiler.getDefine("windowTitle");
+		var fixed = haxe.macro.Compiler.getDefine("windowFixed") == "1";
 		if( title == null )
 			title = "";
 		if( size != null ) {
@@ -98,10 +99,10 @@ class System {
 		#if hlsdl
 			sdl.Sdl.init();
 			@:privateAccess Window.initChars();
-			@:privateAccess Window.inst = new Window(title, width, height);
+			@:privateAccess Window.inst = new Window(title, width, height, fixed);
 			init();
 		#elseif hldx
-			@:privateAccess Window.inst = new Window(title, width, height);
+			@:privateAccess Window.inst = new Window(title, width, height, fixed);
 			init();
 		#else
 			@:privateAccess Window.inst = new Window(title, width, height);

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -33,15 +33,17 @@ class Window {
 
 	static var CODEMAP = [for( i in 0...2048 ) i];
 
-	function new(title:String, width:Int, height:Int) {
+	function new(title:String, width:Int, height:Int, fixed:Bool = false) {
 		this.windowWidth = width;
 		this.windowHeight = height;
 		eventTargets = new List();
 		resizeEvents = new List();
 		#if hlsdl
-		window = new sdl.Window(title, width, height);
+		final sdlFlags = if (!fixed) sdl.Window.SDL_WINDOW_SHOWN | sdl.Window.SDL_WINDOW_RESIZABLE else sdl.Window.SDL_WINDOW_SHOWN;
+		window = new sdl.Window(title, width, height, sdl.Window.SDL_WINDOWPOS_CENTERED, sdl.Window.SDL_WINDOWPOS_CENTERED, sdlFlags);
 		#elseif hldx
-		window = new dx.Window(title, width, height);
+		final dxFlags = if (!fixed) dx.Window.RESIZABLE else 0;
+		window = new dx.Window(title, width, height, dx.Window.CW_USEDEFAULT, dx.Window.CW_USEDEFAULT, dxFlags);
 		#end
 	}
 


### PR DESCRIPTION
https://github.com/HeapsIO/heaps/issues/715

Would be nice to have an option of a fixed window size. I added windowFixed macro to change DX and SDL window create flags to remove the resizable flag. I tried to keep its setup as the same as windowTitle/windowSize. 

This could also be done by adding the define on the Hashlink side, but I was trying to match the current window define macros.

Issue https://github.com/HeapsIO/heaps/issues/417 was closed but I couldn't find how you could possibly change the window creation params to disable window resizing without editing heaps or hashlink.