### PR TITLE
Audio system fixes

### DIFF
--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -644,6 +644,7 @@ class Manager {
 		}
 
 		while(s.buffers.length > 0) unqueueBuffer(s);
+		s.handle.sampleOffset = 0;
 	}
 
 	var targetRate     : Int;

--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -746,7 +746,7 @@ class Manager {
 		}
 
 		if (!checkTargetFormat(data, grp.mono)) {
-			size = samples * targetChannels * Data.formatBytes(targetFormat);
+			size = Math.ceil(samples * (targetRate / data.samplingRate)) * targetChannels * Data.formatBytes(targetFormat);
 			var resampleBytes = getResampleBytes(size);
 			data.resampleBuffer(resampleBytes, 0, bytes, 0, targetRate, targetFormat, targetChannels, samples);
 			bytes = resampleBytes;

--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -644,7 +644,6 @@ class Manager {
 		}
 
 		while(s.buffers.length > 0) unqueueBuffer(s);
-		s.handle.sampleOffset = 0;
 	}
 
 	var targetRate     : Int;

--- a/hxd/snd/NativeChannel.hx
+++ b/hxd/snd/NativeChannel.hx
@@ -1,5 +1,108 @@
 package hxd.snd;
 
+#if hlopenal
+
+import openal.AL;
+import hxd.snd.Manager;
+import hxd.snd.Driver;
+
+@:access(hxd.snd.Manager)
+private class ALChannel {
+
+	static var nativeUpdate : haxe.MainLoop.MainEvent;
+	static var nativeChannels : Array<ALChannel>;
+	
+	static function updateChannels() {
+		var i = 0;
+		// Should ensure ordering if it was removed during update?
+		for ( chn in nativeChannels ) chn.onUpdate();
+	}
+
+	var manager : Manager;
+	var update : haxe.MainLoop.MainEvent;
+	var native : NativeChannel;
+	var samples : Int;
+
+	var driver : Driver;
+	var buffers : Array<BufferHandle>;
+	var bufPos : Int;
+	var src : SourceHandle;
+
+	var fbuf : haxe.io.Bytes;
+	var ibuf : haxe.io.Bytes;
+
+	public function new(samples, native) {
+		if ( nativeUpdate == null ) {
+			nativeUpdate = haxe.MainLoop.add(updateChannels);
+			#if (haxe_ver >= 4) nativeUpdate.isBlocking = false; #end
+			nativeChannels = [];
+		}
+		this.native = native;
+		this.samples = samples;
+
+		this.manager = Manager.get();
+		this.driver = manager.driver;
+
+		buffers = [driver.createBuffer(), driver.createBuffer()];
+		src = driver.createSource();
+		bufPos = 0;
+		
+		// AL.sourcef(src,AL.PITCH,1.0);
+		// AL.sourcef(src,AL.GAIN,1.0);
+		fbuf = haxe.io.Bytes.alloc( samples<<3 );
+		ibuf = haxe.io.Bytes.alloc( samples<<2 );
+
+		for ( b in buffers )
+			onSample(b);
+		forcePlay();
+		nativeChannels.push(this);
+	}
+
+	public function stop() {
+		if ( src != null ) {
+			nativeChannels.remove(this);
+			driver.stopSource(src);
+			driver.destroySource(src);
+			for (buf in buffers)
+				driver.destroyBuffer(buf);
+			src = null;
+			buffers = null;
+		}
+	}
+
+	@:noDebug function onSample( buf : BufferHandle ) {
+		@:privateAccess native.onSample(haxe.io.Float32Array.fromBytes(fbuf));
+
+		// Convert Float32 to Int16
+		for ( i in 0...samples << 1 ) {
+			var v = Std.int(fbuf.getFloat(i << 2) * 0x7FFF);
+			ibuf.set( i<<1, v );
+			ibuf.set( (i<<1) + 1, v>>>8 );
+		}
+		driver.setBufferData(buf, ibuf, ibuf.length, I16, 2, Manager.STREAM_BUFFER_SAMPLE_COUNT);
+		driver.queueBuffer(src, buf, 0, false);
+	}
+
+	inline function forcePlay() {
+		if (!src.playing) driver.playSource(src);
+	}
+
+	function onUpdate(){
+		var cnt = driver.getProcessedBuffers(src);
+		while (cnt > 0)
+		{
+			cnt--;
+			var buf = buffers[bufPos];
+			driver.unqueueBuffer(src, buf);
+			onSample(buf);
+			forcePlay();
+			if (++bufPos == buffers.length) bufPos = 0;
+		}
+	}
+}
+
+#end
+
 #if lime_openal
 import lime.media.openal.AL;
 import lime.media.openal.ALBuffer;
@@ -120,7 +223,7 @@ class NativeChannel {
 	var queued : js.html.audio.AudioBufferSourceNode;
 	var time : Float; // Mandatory for proper buffer sync, otherwise produces gaps in playback due to innacurate timings.
 	var tmpBuffer : haxe.io.Float32Array;
-	#elseif lime_openal
+	#elseif (hlopenal || lime_openal)
 	var channel : ALChannel;
 	#end
 	public var bufferSamples(default, null) : Int;
@@ -160,7 +263,7 @@ class NativeChannel {
 		time = currTime + front.duration;
 		queued.start(time);
 		
-		#elseif lime_openal
+		#elseif (hlopenal || lime_openal)
 		channel = new ALChannel(bufferSamples, this);
 		#end
 	}
@@ -263,7 +366,7 @@ class NativeChannel {
 			bufferPool.push(tmpBuffer);
 			tmpBuffer = null;
 		}
-		#elseif lime_openal
+		#elseif (hlopenal || lime_openal)
 		if( channel != null ) {
 			channel.stop();
 			channel = null;

--- a/hxd/snd/openal/AudioTypes.hx
+++ b/hxd/snd/openal/AudioTypes.hx
@@ -25,6 +25,7 @@ class SourceHandle {
 	var effectToAuxiliarySend : Map<Effect, Int>;
 
 	public function new() {
+		sampleOffset = 0;
 		nextAuxiliarySend = 0;
 		freeAuxiliarySends = [];
 		effectToAuxiliarySend = new Map();

--- a/hxd/snd/openal/Driver.hx
+++ b/hxd/snd/openal/Driver.hx
@@ -98,6 +98,7 @@ class Driver implements hxd.snd.Driver {
 	public function stopSource(source : SourceHandle) : Void {
 		AL.sourceStop(source.inst);
 		source.playing = false;
+		source.sampleOffset = 0;
 	}
 
 	public function setSourceVolume(source : SourceHandle, value : Float) : Void {

--- a/hxd/snd/openal/Emulator.hx
+++ b/hxd/snd/openal/Emulator.hx
@@ -12,6 +12,9 @@ private class Channel extends NativeChannel {
 	public function new(source, samples) {
 		this.source = source;
 		super(samples);
+		#if js
+		gain.gain.setValueAtTime(source.volume, 0);
+		#end
 	}
 
 	@:noDebug
@@ -19,7 +22,7 @@ private class Channel extends NativeChannel {
 		var pos = 0;
 		var count = out.length >> 1;
 		if( source.duration > 0 ) {
-			var volume = source.volume;
+			var volume = #if js 1.0 #else source.volume #end;
 			var bufferIndex = 0;
 			var baseSample = 0;
 			var curSample = source.currentSample;
@@ -308,6 +311,9 @@ class Emulator {
 			}
 		case GAIN:
 			source.volume = value;
+			#if js
+			if (source.chan != null) source.chan.gain.gain.setValueAtTime(value, 0);
+			#end
 		case REFERENCE_DISTANCE, ROLLOFF_FACTOR, MAX_DISTANCE:
 			// nothing (spatialization)
 		case PITCH:

--- a/hxd/snd/openal/Emulator.hx
+++ b/hxd/snd/openal/Emulator.hx
@@ -13,7 +13,7 @@ private class Channel extends NativeChannel {
 		this.source = source;
 		super(samples);
 		#if js
-		gain.gain.setValueAtTime(source.volume, 0);
+		gain.gain.value = source.volume;
 		#end
 	}
 
@@ -254,7 +254,7 @@ class Emulator {
 		#if js
 		switch (param) {
 			case GAIN:
-				hxd.snd.NativeChannel.masterGain.gain.setValueAtTime(value, hxd.snd.NativeChannel.ctx.currentTime);
+				hxd.snd.NativeChannel.masterGain.gain.value = value;
 		}
 		#end
 	}
@@ -312,7 +312,7 @@ class Emulator {
 		case GAIN:
 			source.volume = value;
 			#if js
-			if (source.chan != null) source.chan.gain.gain.setValueAtTime(value, 0);
+			if (source.chan != null) source.chan.gain.gain.value = value;
 			#end
 		case REFERENCE_DISTANCE, ROLLOFF_FACTOR, MAX_DISTANCE:
 			// nothing (spatialization)

--- a/hxd/snd/openal/Emulator.hx
+++ b/hxd/snd/openal/Emulator.hx
@@ -246,7 +246,15 @@ class Emulator {
 	//public static function getProcAddress(fname   : Bytes) : Void*;
 
 	// Set Listener parameters
-	public static function listenerf(param : Int, value  : F32) {}
+	public static function listenerf(param : Int, value  : F32)
+	{
+		#if js
+		switch (param) {
+			case GAIN:
+				hxd.snd.NativeChannel.masterGain.gain.setValueAtTime(value, hxd.snd.NativeChannel.ctx.currentTime);
+		}
+		#end
+	}
 	public static function listener3f(param : Int, value1 : F32, value2 : F32, value3 : F32) {}
 	public static function listenerfv(param : Int, values : Bytes) {}
 	public static function listeneri(param : Int, value  : Int) {}

--- a/samples/Sound.hx
+++ b/samples/Sound.hx
@@ -67,8 +67,9 @@ class Sound extends SampleApp {
 			tf.textAlign = Right;
 			f.addChild(slider);
 			f.addChild(musicPosition);
-
+			#if hlopenal
 			addSlider("Pitch val", function() { return pitch.value; }, function(v) { pitch.value = v; }, 0, 2);
+			#end
 		}
 	}
 

--- a/samples/Sound.hx
+++ b/samples/Sound.hx
@@ -14,41 +14,78 @@ class NoiseChannel extends hxd.snd.NativeChannel {
 }
 
 
-class Sound extends hxd.App {
+class Sound extends SampleApp {
 
 	var time = 0.;
 	var slider : h2d.Slider;
 	var music : hxd.snd.Channel;
+	var musicPosition : h2d.Text;
+	var beeper:Bool = true;
 
 	override function init() {
+		super.init();
+
 		var res = if( hxd.res.Sound.supportedFormat(Mp3) || hxd.res.Sound.supportedFormat(OggVorbis) ) hxd.Res.music_loop else null;
+		var pitch = new hxd.snd.effect.Pitch();
 		if( res != null ) {
 			trace("Playing "+res);
 			music = res.play(true);
 			//music.queueSound(...);
 			music.onEnd = function() trace("LOOP");
+			// Use effect processing on the channel
+			music.addEffect(pitch);
 		}
 
-		slider = new h2d.Slider(300, 10, s2d);
-		slider.x = 150;
-		slider.y = 80;
-		if( music == null ) slider.remove();
+		slider = new h2d.Slider(300, 10);
 		slider.onChange = function() {
 			music.position = slider.value * music.duration;
 		};
+		musicPosition = new h2d.Text(getFont());
+
+		// slider.x = 150;
+		// slider.y = 80;
+		// if( music == null ) slider.remove();
+		// slider.onChange = function() {
+		// 	music.position = slider.value * music.duration;
+		// };
+		// musicPosition.setPosition(460, 80);
+		
+		addSlider("Global vol", function() { return hxd.snd.Manager.get().masterVolume; }, function(v) { hxd.snd.Manager.get().masterVolume = v; });
+		addCheck("Beeper", function() { return beeper; }, function(v) { beeper = v; });
+		addButton("Play noise", function() {
+			var c = new NoiseChannel();
+			haxe.Timer.delay(c.stop, 1000);
+		});
+		if ( music != null ) {
+			addCheck("Music mute", function() { return music.mute; }, function(v) { music.mute = v; });
+			addSlider("Music vol", function() { return music.volume; }, function(v) { music.volume = v; });
+			var f = new h2d.Flow(fui);
+			f.horizontalSpacing = 5;
+			var tf = new h2d.Text(getFont(), f);
+			tf.text = "Music pos";
+			tf.maxWidth = 70;
+			tf.textAlign = Right;
+			f.addChild(slider);
+			f.addChild(musicPosition);
+
+			addSlider("Pitch val", function() { return pitch.value; }, function(v) { pitch.value = v; }, 0, 2);
+		}
 	}
 
 	override function update(dt:Float) {
-		time += dt;
-		if( time > 1 ) {
-			time--;
-			hxd.Res.sound_fx.play();
-			engine.backgroundColor = 0xFFFF0000;
-		} else
-			engine.backgroundColor = 0;
+		if ( beeper ) {
+			time += dt;
+			if( time > 1 ) {
+				time--;
+				hxd.Res.sound_fx.play();
+				engine.backgroundColor = 0xFFFF0000;
+			} else
+				engine.backgroundColor = 0;
+		}
 
 		if( music != null ) {
 			slider.value = music.position / music.duration;
+			musicPosition.text = hxd.Math.fmt(music.position) + "/" + hxd.Math.fmt(music.duration);
 			if( hxd.Key.isPressed(hxd.Key.M) ) {
 				music.mute = !music.mute;
 			}


### PR DESCRIPTION
As per usual, after LD I ended up hating audio system for it's implementation quirks. Time to fix at least some.
* Fixed bug with resampler causing a crash if resampling to higher sample rate (`stb_ogg_sound` on JS crash when using 44100hz ogg resampled to 48000hz)
* Fixed position of the track being broken, because sampleOffset wasn't reset to 0 when stopping source.
* Fixed playback of MP3 on HL. Assuming that mp3 won't have frames with different layers (I couldn't find any samples of such mp3s) - calculations got simplified. Fixed frame offsets calculation.
* Implemented NativeChannel for `hlopenal`. Basically copy-paste of Lime implementation with usage of driver instance. Fixes Sound sample noise not working. Enables code-generated sound on HL in general.
* JS: Implemented `MasterGain`
* JS: Made volume changes on Channel being immediate instead of applied to next buffer fill.
* JS: `Driver.getPlayedSampleCount` no longer returns NaN if AudioContext is in suspended mode during sound startup.
* Improved Sound sample.

I tinkered with current implementation of audio on JS and concluded: It's easier to write custom Driver implementation for WebAudio than doing the Emulator work with it. Would also introduce less overhead.