### PR TITLE
Add `equals` to `Point` classes

### DIFF
--- a/h2d/col/IPoint.hx
+++ b/h2d/col/IPoint.hx
@@ -37,6 +37,10 @@ class IPoint {
 		return new Point(x + p.x, y + p.y);
 	}
 
+	public inline function equals( other : IPoint ) : Bool {
+		return x == other.x && y == other.y;
+	}
+
 	public inline function dot( p : IPoint ) {
 		return x * p.x + y * p.y;
 	}

--- a/h2d/col/Point.hx
+++ b/h2d/col/Point.hx
@@ -37,6 +37,10 @@ class Point {
 		return new Point(x + p.x, y + p.y);
 	}
 
+	public inline function equals( other : Point ) : Bool {
+		return x == other.x && y == other.y;
+	}
+
 	public inline function dot( p : Point ) {
 		return x * p.x + y * p.y;
 	}

--- a/h3d/col/IPoint.hx
+++ b/h3d/col/IPoint.hx
@@ -23,6 +23,10 @@ class IPoint {
 		this.z = z;
 	}
 
+	public inline function equals( other : IPoint ) : Bool {
+		return x == other.x && y == other.y && z == other.z;
+	}
+
 	public inline function load( p : IPoint ) {
 		this.x = p.x;
 		this.y = p.y;

--- a/h3d/col/Point.hx
+++ b/h3d/col/Point.hx
@@ -45,6 +45,10 @@ class Point {
 		return new Point(y * p.z - z * p.y, z * p.x - x * p.z,  x * p.y - y * p.x);
 	}
 
+	public inline function equals( other : Point ) : Bool {
+		return x == other.x && y == other.y && z == other.z;
+	}
+
 	public inline function lengthSq() {
 		return x * x + y * y + z * z;
 	}


### PR DESCRIPTION
I propose adding `equals` methods to the `Point` classes. 
The only one missing is `h3d.col.FPoint` which didn't work on `Windows - HL 1.10` (I didn't test other targets), I suppose that's due to float precision shenanigans.