### PR TITLE
Added compiler flag for disabling window resize

### DIFF
--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -87,6 +87,13 @@ class System {
 		var height = 600;
 		var size = haxe.macro.Compiler.getDefine("windowSize");
 		var title = haxe.macro.Compiler.getDefine("windowTitle");
+		var disableResize = haxe.macro.Compiler.getDefine("windowDisableResize");
+
+		var resizable = true;
+		if (disableResize != null && disableResize != "false") {
+			resizable = false;
+		}
+
 		if( title == null )
 			title = "";
 		if( size != null ) {
@@ -98,10 +105,10 @@ class System {
 		#if hlsdl
 			sdl.Sdl.init();
 			@:privateAccess Window.initChars();
-			@:privateAccess Window.inst = new Window(title, width, height);
+			@:privateAccess Window.inst = new Window(title, width, height, resizable);
 			init();
 		#elseif hldx
-			@:privateAccess Window.inst = new Window(title, width, height);
+			@:privateAccess Window.inst = new Window(title, width, height, resizable);
 			init();
 		#else
 			@:privateAccess Window.inst = new Window(title, width, height);

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -33,15 +33,20 @@ class Window {
 
 	static var CODEMAP = [for( i in 0...2048 ) i];
 
-	function new(title:String, width:Int, height:Int) {
+	function new(title:String, width:Int, height:Int, ?resizable:Bool = true) {
 		this.windowWidth = width;
 		this.windowHeight = height;
 		eventTargets = new List();
 		resizeEvents = new List();
 		#if hlsdl
-		window = new sdl.Window(title, width, height);
+		var windowFlags = sdl.Window.SDL_WINDOW_SHOWN;
+		if (resizable) {
+			windowFlags |= sdl.Window.SDL_WINDOW_RESIZABLE;
+		}
+		window = new sdl.Window(title, width, height, sdl.Window.SDL_WINDOWPOS_CENTERED, sdl.Window.SDL_WINDOWPOS_CENTERED, windowFlags);
 		#elseif hldx
-		window = new dx.Window(title, width, height);
+		var windowFlags = resizable ? dx.Window.RESIZABLE : dx.Window.CW_USEDEFAULT;
+		window = new dx.Window(title, width, height, dx.Window.CW_USEDEFAULT, dx.Window.CW_USEDEFAULT, windowFlags);
 		#end
 	}
 


### PR DESCRIPTION
Compiling to hl using hldx or hlsdl with `-D windowDisableResize`
will create a window that is not resizable.