### PR TITLE
Fix `h2d.Console` scaling

### DIFF
--- a/h2d/Console.hx
+++ b/h2d/Console.hx
@@ -423,9 +423,8 @@ class Console #if !macro extends h2d.Object #end {
 		var scene = ctx.scene;
 		if( scene != null ) {
 			x = 0;
-			y = scene.height - height;
-			width = scene.width;
-			tf.maxWidth = width;
+			y = (scene.height / scene.matD) - height * scaleY;
+			width = Math.ceil(scene.width / scene.matA); 
 			bg.tile.scaleToSize(width, height);
 		}
 		var log = logTxt;


### PR DESCRIPTION
This fix is necessary to prevent the console from going out of the screen after being scaled up.

Here's a little [test project](https://github.com/HeapsIO/heaps/files/3765198/console_scaling_test.zip). Notice that I changed the console key in the project to `'` because it's easier for the Brazilian keyboard.
