### PR TITLE
Js touch detection

### DIFF
--- a/hxd/System.js.hx
+++ b/hxd/System.js.hx
@@ -101,6 +101,7 @@ class System {
 	public static function getValue( s : SystemValue ) : Bool {
 		return switch( s ) {
 		case IsWindowed: true;
+		case IsTouch: platform==Android || platform==IOS;
 		default: false;
 		}
 	}
@@ -125,7 +126,15 @@ class System {
 	static function get_width() : Int return Math.round(js.Browser.document.body.clientWidth * js.Browser.window.devicePixelRatio);
 	static function get_height() : Int return Math.round(js.Browser.document.body.clientHeight  * js.Browser.window.devicePixelRatio);
 	static function get_lang() : String return "en";
-	static function get_platform() : Platform return PC;
+	static function get_platform() : Platform {
+		var ua = js.Browser.navigator.userAgent.toLowerCase();
+		if( ua.indexOf("android")>=0 )
+			return Android;
+		else if( ua.indexOf("ipad")>=0 || ua.indexOf("iphone")>=0 || ua.indexOf("ipod")>=0 )
+			return IOS;
+		else
+			return PC;
+	}
 	static function get_screenDPI() : Int return 72;
 	static function get_allowTimeout() return false;
 	static function set_allowTimeout(b) return false;

--- a/hxd/System.js.hx
+++ b/hxd/System.js.hx
@@ -102,6 +102,7 @@ class System {
 		return switch( s ) {
 		case IsWindowed: true;
 		case IsTouch: platform==Android || platform==IOS;
+		case IsMobile: platform==Android || platform==IOS;
 		default: false;
 		}
 	}


### PR DESCRIPTION
Added basic device detection based on user-agent. Enables support for IsTouch & IsMobile detections on JS target.

Not perfect detection, but it works for most platforms, and there's no better solution without relying on external libs.