### PR TITLE
Fix event ordering when setting s2d via App.setScene

### DIFF
--- a/hxd/App.hx
+++ b/hxd/App.hx
@@ -66,11 +66,14 @@ class App implements h3d.IDrawable {
 	public function setScene( scene : hxd.SceneEvents.InteractiveScene, disposePrevious = true ) {
 		var new2D = hxd.impl.Api.downcast(scene, h2d.Scene);
 		var new3D = hxd.impl.Api.downcast(scene, h3d.scene.Scene);
-		if( new2D != null )
+		if( new2D != null ) {
 			sevents.removeScene(s2d);
-		if( new3D != null )
-			sevents.removeScene(s3d);
-		sevents.addScene(scene);
+			sevents.addScene(scene, 0);
+		} else {
+			if( new3D != null )
+				sevents.removeScene(s3d);
+			sevents.addScene(scene);
+		}
 		if( disposePrevious ) {
 			if( new2D != null )
 				s2d.dispose();


### PR DESCRIPTION
That one was a thorn in my side for half a year already.
When setting 2D scene via `App.setScene`, it screwed up the event ordering, causing it to receive events after s3d.