### PR TITLE
WIP: Basis support

### DIFF
--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -799,7 +799,7 @@ class GlDriver extends Driver {
 		case SRGB, SRGB_ALPHA: hasFeature(SRGBTextures);
 		case R8, RG8, RGB8, R16F, RG16F, RGB16F, R32F, RG32F, RGB32F, RG11B10UF, RGB10A2: #if js glES >= 3 #else true #end;
 		case S3TC(n): n <= maxCompressedTexturesSupport;
-		case ASTC(_), ETC(_), S3TC(_), PVRTC(_): #if js true #else false #end;
+		case ASTC(_), ETC(_), PVRTC(_): #if js true #else false #end;
 		default: false;
 		}
 	}

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -907,7 +907,7 @@ class GlDriver extends Driver {
 
 		if( t.flags.has(Cube) ) {
 			for( i in 0...6 ) {
-				gl.texImage2D(CUBE_FACES[i], 0, tt.internalFmt, tt.width, tt.height, 0, getChannels(tt), tt.pixelFmt, null);
+					gl.texImage2D(CUBE_FACES[i], 0, tt.internalFmt, tt.width, tt.height, 0, getChannels(tt), tt.pixelFmt, null);				
 				if( checkError() ) break;
 			}
 		} else if( t.flags.has(IsArray) ) {
@@ -915,7 +915,7 @@ class GlDriver extends Driver {
 			checkError();
 		} else {
 			#if js
-			if( !t.format.match(S3TC(_)) )
+			if( !t.format.match(S3TC(_)) && !t.format.match(ETC(_)) && !t.format.match(ASTC(_)) && !t.format.match(PVRTC(_))) 
 			#end
 			gl.texImage2D(bind, 0, tt.internalFmt, tt.width, tt.height, 0, getChannels(tt), tt.pixelFmt, null);
 			checkError();
@@ -1555,7 +1555,7 @@ class GlDriver extends Driver {
 	}
 
 	#if js
-	function checkTextureSupport():hxd.PixelFormat {
+	public function checkTextureSupport():hxd.PixelFormat {
 		var astcSupported = gl.getExtension('WEBGL_compressed_texture_astc') != null;
 		var dxtSupported = gl.getExtension('WEBGL_compressed_texture_s3tc') != null;
 		var pvrtcSupported = gl.getExtension('WEBGL_compressed_texture_pvrtc') != null

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -1,4 +1,5 @@
 package h3d.impl;
+import js.lib.Uint8ClampedArray;
 import h3d.impl.Driver;
 import h3d.mat.Pass;
 import h3d.mat.Stencil;
@@ -1154,6 +1155,7 @@ class GlDriver extends Driver {
 		case RGBA32F, R32F, RG32F, RGB32F: new Float32Array(@:privateAccess pixels.bytes.b.buffer, pixels.offset, bufLen>>2);
 		case RGBA16F, R16F, RG16F, RGB16F: new Uint16Array(@:privateAccess pixels.bytes.b.buffer, pixels.offset, bufLen>>1);
 		case RGB10A2, RG11B10UF: new Uint32Array(@:privateAccess pixels.bytes.b.buffer, pixels.offset, bufLen>>2);
+		case ETC(_), PVRTC(_): new Uint8Array(@:privateAccess pixels.bytes.b.buffer, pixels.offset);
 		default: new Uint8Array(@:privateAccess pixels.bytes.b.buffer, pixels.offset, bufLen);
 		}
 		switch (t.format) {
@@ -1561,15 +1563,14 @@ class GlDriver extends Driver {
 		var pvrtcSupported = gl.getExtension('WEBGL_compressed_texture_pvrtc') != null
 			|| gl.getExtension('WEBKIT_WEBGL_compressed_texture_pvrtc') != null;
 		var etcSupported = gl.getExtension('WEBGL_compressed_texture_etc1') != null;
-
 		return if(astcSupported) {
 			hxd.PixelFormat.ASTC();
 		} else if(dxtSupported){
 			hxd.PixelFormat.S3TC();
+		} else  if(pvrtcSupported){
+			hxd.PixelFormat.PVRTC();
 		} else if(etcSupported){
 			hxd.PixelFormat.ETC();
-		} else if(pvrtcSupported){
-			hxd.PixelFormat.PVRTC();
 		} else {
 			null;
 		}

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -883,6 +883,7 @@ class GlDriver extends Driver {
 		case PVRTC(n):
 			checkMult4(t);
 			switch(n) {
+			case 8: tt.internalFmt = hxd.PixelFormat.PVRTC_FORMAT.RGB_4BPPV1;
 			case 9: tt.internalFmt = hxd.PixelFormat.PVRTC_FORMAT.RGBA_4BPPV1;
 			default: throw "Unsupported texture format "+t.format;
 			}

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -799,6 +799,7 @@ class GlDriver extends Driver {
 		case SRGB, SRGB_ALPHA: hasFeature(SRGBTextures);
 		case R8, RG8, RGB8, R16F, RG16F, RGB16F, R32F, RG32F, RGB32F, RG11B10UF, RGB10A2: #if js glES >= 3 #else true #end;
 		case S3TC(n): n <= maxCompressedTexturesSupport;
+		case ASTC(_), ETC(_), S3TC(_), PVRTC(_): #if js true #else false #end;
 		default: false;
 		}
 	}

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -1,5 +1,4 @@
 package h3d.impl;
-import js.lib.Uint8ClampedArray;
 import h3d.impl.Driver;
 import h3d.mat.Pass;
 import h3d.mat.Stencil;

--- a/hxd/PixelFormat.hx
+++ b/hxd/PixelFormat.hx
@@ -19,5 +19,27 @@ enum PixelFormat {
 	SRGB_ALPHA;
 	RGB10A2;
 	RG11B10UF; // unsigned float
-	S3TC( v : Int );
+	ASTC( ?v : Int );
+	ETC( ?v : Int );
+	S3TC( ?v : Int );
+	PVRTC( ?v : Int);
+}
+
+enum abstract ASTC_FORMAT(Int) from Int to Int {
+	final RGBA_4x4 = 0x93B0;
+}
+
+enum abstract DXT_FORMAT(Int) from Int to Int {
+	final RGBA_DXT1 = 0x83F1;
+	final RGBA_DXT3 = 0x83F2;
+	final RGBA_DXT5 = 0x83F3;
+}
+
+enum abstract ETC_FORMAT(Int) from Int to Int {
+	final RGB_ETC1 = 0x8D64;
+}
+
+enum abstract PVRTC_FORMAT(Int) from Int to Int {
+	final RGB_4BPPV1 = 0x8C00;
+	final RGBA_4BPPV1 = 0x8C02;
 }

--- a/hxd/Pixels.hx
+++ b/hxd/Pixels.hx
@@ -423,9 +423,7 @@ class Pixels {
 		case RGB32F: 12;
 		case RGB10A2: 4;
 		case RG11B10UF: 4;
-		case ASTC(n): 1;
-		case ETC(n): 0;
-		case PVRTC(n): 0;
+		case ASTC(n), ETC(n), PVRTC(n): 1;
 		case S3TC(n):
 			if( n == 1 || n == 4 )
 				return width >> 1;

--- a/hxd/Pixels.hx
+++ b/hxd/Pixels.hx
@@ -321,6 +321,9 @@ class Pixels {
 			}
 
 		case [S3TC(a),S3TC(b)] if( a == b ):
+		case [ASTC(a),ASTC(b)] if( a == b ):
+		case [ETC(a),ETC(b)] if( a == b ):
+		case [PVRTC(a),PVRTC(b)] if( a == b ):
 			// nothing
 
 		#if (hl && hl_ver >= "1.10")

--- a/hxd/Pixels.hx
+++ b/hxd/Pixels.hx
@@ -420,6 +420,9 @@ class Pixels {
 		case RGB32F: 12;
 		case RGB10A2: 4;
 		case RG11B10UF: 4;
+		case ASTC(n): 1;
+		case ETC(n): 0;
+		case PVRTC(n): 0;
 		case S3TC(n):
 			if( n == 1 || n == 4 )
 				return width >> 1;
@@ -455,7 +458,7 @@ class Pixels {
 			channel.toInt() * 4;
 		case RGB10A2, RG11B10UF:
 			throw "Bit packed format";
-		case S3TC(_):
+		case S3TC(_), ASTC(_), ETC(_), PVRTC(_):
 			throw "Not supported";
 		}
 	}

--- a/hxd/net/BinaryLoader.hx
+++ b/hxd/net/BinaryLoader.hx
@@ -21,7 +21,7 @@ class BinaryLoader {
 		throw msg;
 	}
 
-	public function load() {
+	public function load(raw = false) {
 		#if flash
 		loader = new flash.net.URLLoader();
 		loader.dataFormat = flash.net.URLLoaderDataFormat.BINARY;
@@ -43,7 +43,7 @@ class BinaryLoader {
 				onError(xhr.statusText);
 				return;
 			}
-			onLoaded(haxe.io.Bytes.ofData(xhr.response));
+			onLoaded(raw ? xhr.response : haxe.io.Bytes.ofData(xhr.response));
 		}
 		
 		xhr.onprogress = function(e) {

--- a/hxd/res/BasisTextureLoader.hx
+++ b/hxd/res/BasisTextureLoader.hx
@@ -38,7 +38,7 @@ class BasisTextureLoader {
 		final extETC1 = context.getExtension('WEBGL_compressed_texture_etc1');
 		final extDXT = context.getExtension('WEBGL_compressed_texture_s3tc');
 		final extPVRTC = context.getExtension('WEBGL_compressed_texture_pvrtc') != null ? context.getExtension('WEBGL_compressed_texture_pvrtc') : context.getExtension('WEBKIT_WEBGL_compressed_texture_pvrtc');
-		
+
 		_workerConfig.astcSupported = extASTC != null;
 		_workerConfig.etc1Supported = extETC1 != null;
 		_workerConfig.dxtSupported = extDXT != null;
@@ -281,7 +281,6 @@ class BasisWorker {
                                 buffers.push( mipmaps[ i ].data.buffer );
 
                             }
-                            console.log('transcode', buffers.length);
                             self.postMessage( { type: 'transcode', id: message.id, width, height, hasAlpha, mipmaps, format }, buffers );
 
                         } catch ( error ) {
@@ -399,5 +398,4 @@ class BasisWorker {
 
     }";
 }
-
 #end

--- a/hxd/res/BasisTextureLoader.hx
+++ b/hxd/res/BasisTextureLoader.hx
@@ -1,0 +1,402 @@
+package hxd.res;
+
+import hxd.PixelFormat;
+import js.html.ImageData;
+import h3d.mat.Texture;
+import h3d.impl.GlDriver;
+import h3d.mat.Data;
+
+class BasisTextureLoader {
+	public static var workerLimit = 4;
+	public static var transcoderPath = 'vendor/basis_transcoder.js';
+	public static var wasmPath = 'vendor/basis_transcoder.wasm';
+
+	static var _workerNextTaskID = 1;
+	static var _workerSourceURL:String;
+	static var _workerConfig = {
+		format: 0,
+		astcSupported: false,
+		etc1Supported: false,
+		etc2Supported: false,
+		dxtSupported: false,
+		pvrtcSupported: false,
+	};
+	static var _workerPool:Array<WorkerTask> = [];
+	static var _transcoderPending:js.lib.Promise<Dynamic>;
+	static var _transcoderBinary:Dynamic;
+
+	public static function getTexture(bytes:haxe.io.BytesData) {
+		detectSupport();
+		return createTexture(bytes);
+	}
+
+	static function detectSupport() {
+		final driver:GlDriver = cast h3d.Engine.getCurrent().driver;
+		final context = driver.gl;
+
+		final extASTC = context.getExtension('WEBGL_compressed_texture_astc');
+		final extETC1 = context.getExtension('WEBGL_compressed_texture_etc1');
+		final extDXT = context.getExtension('WEBGL_compressed_texture_s3tc');
+		final extPVRTC = context.getExtension('WEBGL_compressed_texture_pvrtc') != null ? context.getExtension('WEBGL_compressed_texture_pvrtc') : context.getExtension('WEBKIT_WEBGL_compressed_texture_pvrtc');
+		
+		_workerConfig.astcSupported = extASTC != null;
+		_workerConfig.etc1Supported = extETC1 != null;
+		_workerConfig.dxtSupported = extDXT != null;
+		_workerConfig.pvrtcSupported = extPVRTC != null;
+
+		if (_workerConfig.etc1Supported) {
+			_workerConfig.format = BASIS_FORMAT.cTFETC1;
+		} else if (_workerConfig.astcSupported) {
+			_workerConfig.format = BASIS_FORMAT.cTFASTC_4x4;
+		} else if (_workerConfig.dxtSupported) {
+			_workerConfig.format = BASIS_FORMAT.cTFBC3;
+		} else if (_workerConfig.pvrtcSupported) {
+			_workerConfig.format = BASIS_FORMAT.cTFPVRTC1_4_RGBA;
+		} else {
+			throw 'No suitable compressed texture format found.';
+		};
+	}
+
+	static function createTexture(buffer:haxe.io.BytesData):js.lib.Promise<h3d.mat.Texture> {
+		var worker:js.html.Worker;
+		var workerTask:WorkerTask;
+		var taskID:Int;
+		var texturePending = getWorker().then((task) -> {
+			workerTask = task;
+			worker = workerTask.worker;
+			taskID = _workerNextTaskID++;
+			return new js.lib.Promise((resolve, reject) -> {
+				workerTask.callbacks.set(taskID, {
+					resolve: resolve,
+					reject: reject,
+				});
+				workerTask.taskCosts.set(taskID, buffer.byteLength);
+				workerTask.taskLoad += workerTask.taskCosts.get(taskID);
+				worker.postMessage({type: 'transcode', id: taskID, buffer: buffer}, [buffer]);
+			});
+		}).then((message) -> {
+				final w = message.width;
+				final h = message.height;
+				final mipmaps:Array<ImageData> = message.mipmaps;
+				final format = message.format;
+				final create = (fmt) -> {
+					final texture = new h3d.mat.Texture(w, h, null, fmt);
+					var level = 0;
+					for (mipmap in mipmaps) {
+						final pixels = new hxd.Pixels(mipmap.width, mipmap.height, haxe.io.Bytes.ofData(cast mipmap.data), fmt);
+						texture.uploadPixels(pixels, level);
+						level++;
+					}
+					return texture;
+				}
+				var texture:h3d.mat.Texture;
+				switch (format) {
+					case BASIS_FORMAT.cTFASTC_4x4:
+						texture = create(hxd.PixelFormat.ASTC(format));
+					case BASIS_FORMAT.cTFBC1, BASIS_FORMAT.cTFBC3:
+						texture = create(hxd.PixelFormat.S3TC(format));
+					case BASIS_FORMAT.cTFETC1:
+						texture = create(hxd.PixelFormat.ETC(format));
+					case BASIS_FORMAT.cTFPVRTC1_4_RGB, BASIS_FORMAT.cTFPVRTC1_4_RGBA:
+						texture = create(hxd.PixelFormat.PVRTC(format));
+					default:
+						throw 'BasisTextureLoader: No supported format available.';
+				}
+				if (mipmaps.length > 1) {
+					texture.flags.set(MipMapped);
+				}
+				return texture;
+			}).then((tex) -> {
+				if (workerTask != null && taskID > 0) {
+					workerTask.taskLoad -= workerTask.taskCosts.get(taskID);
+					workerTask.callbacks.remove(taskID);
+					workerTask.taskCosts.remove(taskID);
+				}
+				return tex;
+			});
+		return texturePending;
+	}
+
+	static function initTranscoder() {
+		if (_transcoderBinary == null) {
+			// Load transcoder wrapper.
+			final jsLoader = new hxd.net.BinaryLoader(transcoderPath);
+			final jsContent = new js.lib.Promise((resolve, reject) -> {
+				jsLoader.onLoaded = resolve;
+				jsLoader.onError = reject;
+				jsLoader.load();
+			});
+			// Load transcoder WASM binary.
+			final binaryLoader = new hxd.net.BinaryLoader(wasmPath);
+			final binaryContent = new js.lib.Promise((resolve, reject) -> {
+				binaryLoader.onLoaded = resolve;
+				binaryLoader.onError = reject;
+				binaryLoader.load(true);
+			});
+
+			_transcoderPending = js.lib.Promise.all([jsContent, binaryContent]).then((arr) -> {
+				final transcoder = arr[0];
+				final wasm = arr[1];
+				var fn = BasisWorker.func;
+
+				var body = [
+					'/* basis_transcoder.js */',
+					transcoder,
+					'/* worker */',
+					fn.substring(fn.indexOf('{') + 1, fn.lastIndexOf('}'))
+				].join('\n');
+
+				_workerSourceURL = js.html.URL.createObjectURL(new js.html.Blob([body]));
+				_transcoderBinary = wasm;
+			});
+		}
+
+		return _transcoderPending;
+	}
+
+	static function getWorker() {
+		return initTranscoder().then((val) -> {
+			if (_workerPool.length < workerLimit) {
+				final worker = new js.html.Worker(_workerSourceURL);
+				final workerTask:WorkerTask = {
+					worker: worker,
+					callbacks: new haxe.ds.IntMap(),
+					taskCosts: new haxe.ds.IntMap(),
+					taskLoad: 0,
+				}
+
+				worker.postMessage({
+					type: 'init',
+					config: _workerConfig,
+					transcoderBinary: _transcoderBinary,
+				});
+
+				worker.onmessage = function(e) {
+					var message = e.data;
+
+					switch (message.type) {
+						case 'transcode':
+							workerTask.callbacks.get(message.id).resolve(message);
+						case 'error':
+							workerTask.callbacks.get(message.id).reject(message);
+						default:
+							throw 'BasisTextureLoader: Unexpected message, "' + message.type + '"';
+					}
+				};
+
+				_workerPool.push(workerTask);
+			} else {
+				_workerPool.sort(function(a, b) {
+					return a.taskLoad > b.taskLoad ? -1 : 1;
+				});
+			}
+
+			return _workerPool[_workerPool.length - 1];
+		});
+	}
+}
+
+enum abstract BASIS_FORMAT(Int) from Int to Int {
+	final cTFETC1 = 0;
+	final cTFETC2 = 1;
+	final cTFBC1 = 2;
+	final cTFBC3 = 3;
+	final cTFBC4 = 4;
+	final cTFBC5 = 5;
+	final cTFBC7_M6_OPAQUE_ONLY = 6;
+	final cTFBC7_M5 = 7;
+	final cTFPVRTC1_4_RGB = 8;
+	final cTFPVRTC1_4_RGBA = 9;
+	final cTFASTC_4x4 = 10;
+	final cTFATC_RGB = 11;
+	final cTFATC_RGBA_INTERPOLATED_ALPHA = 12;
+	final cTFRGBA32 = 13;
+	final cTFRGB565 = 14;
+	final cTFBGR565 = 15;
+	final cTFRGBA4444 = 16;
+}
+
+enum abstract FORMAT(Int) from Int to Int {
+	final RGB_S3TC_DXT1_Format = 33776;
+	final RGBA_S3TC_DXT1_Format = 33777;
+	final RGBA_S3TC_DXT3_Format = 33778;
+	final RGBA_S3TC_DXT5_Format = 33779;
+	final RGB_PVRTC_4BPPV1_Format = 35840;
+	final RGB_PVRTC_2BPPV1_Format = 35841;
+	final RGBA_PVRTC_4BPPV1_Format = 35842;
+	final RGBA_PVRTC_2BPPV1_Format = 35843;
+	final RGB_ETC1_Format = 36196;
+	final RGBA_ASTC_4x4_Format = 37808;
+	final RGBA_ASTC_5x4_Format = 37809;
+	final RGBA_ASTC_5x5_Format = 37810;
+	final RGBA_ASTC_6x5_Format = 37811;
+	final RGBA_ASTC_6x6_Format = 37812;
+	final RGBA_ASTC_8x5_Format = 37813;
+	final RGBA_ASTC_8x6_Format = 37814;
+	final RGBA_ASTC_8x8_Format = 37815;
+	final RGBA_ASTC_10x5_Format = 37816;
+	final RGBA_ASTC_10x6_Format = 37817;
+	final RGBA_ASTC_10x8_Format = 37818;
+	final RGBA_ASTC_10x10_Format = 37819;
+	final RGBA_ASTC_12x10_Format = 37820;
+	final RGBA_ASTC_12x12_Format = 37821;
+}
+
+typedef WorkerTask = {
+	worker:js.html.Worker,
+	callbacks:haxe.ds.IntMap<{resolve:(value:Dynamic) -> Void, reject:(reason:Dynamic) -> Void}>,
+	taskCosts:haxe.ds.IntMap<Int>,
+	taskLoad:Int,
+}
+
+class BasisWorker {
+	static public final func = "function () {
+
+        var config;
+        var transcoderPending;
+        var _BasisFile;
+
+        onmessage = function ( e ) {
+
+            var message = e.data;
+
+            switch ( message.type ) {
+
+                case 'init':
+                    config = message.config;
+                    init( message.transcoderBinary );
+                    break;
+
+                case 'transcode':
+                    transcoderPending.then( () => {
+
+                        try {
+
+                            var { width, height, hasAlpha, mipmaps, format } = transcode( message.buffer );
+
+                            var buffers = [];
+
+                            for ( var i = 0; i < mipmaps.length; ++ i ) {
+
+                                buffers.push( mipmaps[ i ].data.buffer );
+
+                            }
+                            console.log('transcode', buffers.length);
+                            self.postMessage( { type: 'transcode', id: message.id, width, height, hasAlpha, mipmaps, format }, buffers );
+
+                        } catch ( error ) {
+
+                            console.error( error );
+
+                            self.postMessage( { type: 'error', id: message.id, error: error.message } );
+
+                        }
+
+                    } );
+                    break;
+
+            }
+
+        };
+
+        function init( wasmBinary ) {
+
+            var BasisModule;
+            transcoderPending = new Promise( ( resolve ) => {
+
+                BasisModule = { wasmBinary, onRuntimeInitialized: resolve };
+                BASIS( BasisModule );
+
+            } ).then( () => {
+
+                var { BasisFile, initializeBasis } = BasisModule;
+
+                _BasisFile = BasisFile;
+
+                initializeBasis();
+
+            } );
+
+        }
+
+        function transcode( buffer ) {
+
+            var basisFile = new _BasisFile( new Uint8Array( buffer ) );
+
+            var width = basisFile.getImageWidth( 0, 0 );
+            var height = basisFile.getImageHeight( 0, 0 );
+            var levels = basisFile.getNumLevels( 0 );
+            var hasAlpha = basisFile.getHasAlpha();
+
+            function cleanup() {
+
+                basisFile.close();
+                basisFile.delete();
+
+            }
+
+            if ( ! hasAlpha ) {
+
+                switch ( config.format ) {
+
+                    case 9: // Hardcoded: BASIS_FORMAT.cTFPVRTC1_4_RGBA
+                        config.format = 8; // BASIS_FORMAT.cTFPVRTC1_4_RGB;
+                        break;
+                    default:
+                        break;
+
+                }
+
+            }
+
+            if ( ! width || ! height || ! levels ) {
+
+                cleanup();
+                throw new Error( 'BasisTextureLoader:  Invalid .basis file' );
+
+            }
+
+            if ( ! basisFile.startTranscoding() ) {
+
+                cleanup();
+                throw new Error( 'BasisTextureLoader: .startTranscoding failed' );
+
+            }
+
+            var mipmaps = [];
+
+            for ( var mip = 0; mip < levels; mip ++ ) {
+
+                var mipWidth = basisFile.getImageWidth( 0, mip );
+                var mipHeight = basisFile.getImageHeight( 0, mip );
+                var dst = new Uint8Array( basisFile.getImageTranscodedSizeInBytes( 0, mip, config.format ) );
+
+                var status = basisFile.transcodeImage(
+                    dst,
+                    0,
+                    mip,
+                    config.format,
+                    0,
+                    hasAlpha
+                );
+
+                if ( ! status ) {
+
+                    cleanup();
+                    throw new Error( 'BasisTextureLoader: .transcodeImage failed.' );
+
+                }
+
+                mipmaps.push( { data: dst, width: mipWidth, height: mipHeight } );
+
+            }
+
+            cleanup();
+
+            return { width, height, hasAlpha, mipmaps, format: config.format };
+
+        }
+
+    }";
+}
+

--- a/hxd/res/BasisTextureLoader.hx
+++ b/hxd/res/BasisTextureLoader.hx
@@ -1,5 +1,5 @@
 package hxd.res;
-
+#if js
 import hxd.PixelFormat;
 import js.html.ImageData;
 import h3d.mat.Texture;
@@ -400,3 +400,4 @@ class BasisWorker {
     }";
 }
 
+#end

--- a/hxd/res/Image.hx
+++ b/hxd/res/Image.hx
@@ -218,6 +218,7 @@ class Image extends Resource {
 			var bytes = entry.getBytes();
 			pixels = new hxd.Pixels(inf.width, inf.height, bytes, S3TC(inf.bc), 128 + (inf.bc >= 6 ? 20 : 0));
 		case Basis:
+			#if js
 			var bytes = entry.getBytes();
 			var driver:h3d.impl.GlDriver = cast h3d.Engine.getCurrent().driver;
 			var f = switch(driver.checkTextureSupport()) {
@@ -228,6 +229,9 @@ class Image extends Resource {
 				default: throw 'Unsupported basis texture';
 			}
 			pixels = new hxd.Pixels(inf.width, inf.height, bytes, f);
+			#else
+			throw 'Basis only supported on js target';
+			#end
 		}
 
 		if( fmt != null ) pixels.convert(fmt);

--- a/hxd/res/Image.hx
+++ b/hxd/res/Image.hx
@@ -131,16 +131,9 @@ class Image extends Resource {
 				throw entry.path+" has unsupported 4CC "+String.fromCharCode(fourCC&0xFF)+String.fromCharCode((fourCC>>8)&0xFF)+String.fromCharCode((fourCC>>16)&0xFF)+String.fromCharCode(fourCC>>>24);
 		case 0x4273:
 			format = Basis;
-			f.skip(12);
-			var slices = f.readUInt24();
-			var images = f.readUInt24();
-			var bFormat = f.readInt8();
-			f.skip(44);
+			f.skip(63);
 			var slicesPos = f.readInt32();
-			f.skip(slicesPos-48);
-			var imageIndex = f.readUInt24();
-			var levelIndex = f.readInt8();
-			var flags = f.readInt8();
+			f.skip(slicesPos-42);
 			width = f.readUInt16();
 			height = f.readUInt16();
 		case _ if( entry.extension == "tga" ):


### PR DESCRIPTION
Support for loading basis files (https://github.com/BinomialLLC/basis_universal).

It is working as is, but still a WIP for a few reasons:

1. Support is tested for DXT, ATSC and PVRTC, but having issues with ETC.
2. Integrate with asset system. 
3. Include basis transcoder and wasm binary.

...

1.
Not sure when ETC is needed, but will see if I can find why it is not working. DXT, ATSC and PVRTC seems to cover desktop and mobile browsers well though.

2.
Since we handle loading without depending on assets system in heaps, this is not really a priority for us and seems a bit tricky to do. One reason being that basis adds another async stage to the process (first the usual loading, and then running wasm), so rather than adding another supported format all asset handling needs to be modified to be async both when loading and parsing. Any help on this would be much appreciated.
At the moment is has to be used through BasisTextureLoader.getTexture. Current solution we use in our games looks like this:
```
function getImageTexture(path:String, ext:String, name:String):js.lib.Promise<h3d.mat.Texture> {
	return switch ext {
		case 'basis':
			final bytes = _fileSystem.get(path).getBytes().getData();
			hxd.res.BasisTextureLoader.getTexture(bytes);
		default:
			final bytes = _fileSystem.get(path).getBytes();
			js.lib.Promise.resolve(hxd.res.Any.fromBytes(name, bytes).toTexture());
	}
}
```

3.
Unsure if .js and .wasm needed should be checked in to heaps and added to build folder as needed. 