### PR TITLE
Make Drawable.color to not affect the filter

### DIFF
--- a/h2d/Drawable.hx
+++ b/h2d/Drawable.hx
@@ -8,7 +8,6 @@ class Drawable extends Object {
 
 	/**
 		The color multiplier for the object. Can be used to adjust individually each of the four channels R,G,B,A (default [1,1,1,1])
-		Alpha channel can be used to manipulate object transparency but leave transparency of active filter intact.
 	**/
 	public var color(default,default) : h3d.Vector;
 

--- a/h2d/Drawable.hx
+++ b/h2d/Drawable.hx
@@ -8,6 +8,7 @@ class Drawable extends Object {
 
 	/**
 		The color multiplier for the object. Can be used to adjust individually each of the four channels R,G,B,A (default [1,1,1,1])
+		Alpha channel can be used to manipulate object transparency but leave transparency of active filter intact.
 	**/
 	public var color(default,default) : h3d.Vector;
 

--- a/h2d/Object.hx
+++ b/h2d/Object.hx
@@ -61,6 +61,7 @@ class Object #if (domkit && !domkit_heaps) implements domkit.Model<h2d.Object> #
 
 	/**
 		The amount of transparency of the Object (default 1.0)
+		If there is a filter active, dictates filter transparency as well.
 	**/
 	public var alpha : Float = 1.;
 

--- a/h2d/Object.hx
+++ b/h2d/Object.hx
@@ -61,12 +61,12 @@ class Object #if (domkit && !domkit_heaps) implements domkit.Model<h2d.Object> #
 
 	/**
 		The amount of transparency of the Object (default 1.0)
-		If there is a filter active, dictates filter transparency as well.
 	**/
 	public var alpha : Float = 1.;
 
 	/**
 		The post process filter for this object.
+		When set, `alpha` value affects both filter and object transparency (use `Drawable.color.a` to set transparency only for the object).
 	**/
 	public var filter(default,set) : h2d.filter.Filter;
 

--- a/h2d/RenderContext.hx
+++ b/h2d/RenderContext.hx
@@ -311,12 +311,11 @@ class RenderContext extends h3d.impl.RenderContext {
 	}
 
 	inline function setupColor( obj : h2d.Drawable ) {
-		if( inFilter == obj )
-			baseShader.color.set(1,1,1,1);
+		if( inFilter == obj ) {
+			baseShader.color.set(obj.color.r,obj.color.g,obj.color.b,obj.color.a);
+		}
 		else if( inFilterBlend != null ) {
-			// alpha premult
-			var alpha = obj.color.a * globalAlpha;
-			baseShader.color.set(obj.color.r * alpha, obj.color.g * alpha, obj.color.b * alpha, alpha);
+			baseShader.color.set(globalAlpha,globalAlpha,globalAlpha,globalAlpha);
 		} else
 			baseShader.color.set(obj.color.r, obj.color.g, obj.color.b, obj.color.a * globalAlpha);
 	}


### PR DESCRIPTION
* `Drawable.color` affects only object itself and not the filter.
* `Object.alpha` affects transparency of both object and filter.
* `Drawable.color.a` can be used to manipulate object transparency while inside filter.

Change probably should be tested internally in case it borks stuff in Northgard or something ;)

Fixes #670 