### PR TITLE
Add version for converts

### DIFF
--- a/hxd/fs/Convert.hx
+++ b/hxd/fs/Convert.hx
@@ -6,6 +6,11 @@ class Convert {
 	public var sourceExt(default,null) : String;
 	public var destExt(default,null) : String;
 
+	/**
+		Major version of the Convert.
+		When incremented, all files processed by this Convert would be rebuilt. **/
+	public var version(default, null) : Int;
+
 	public var params : Dynamic;
 
 	public var srcPath : String;
@@ -16,6 +21,7 @@ class Convert {
 	public function new( sourceExt, destExt ) {
 		this.sourceExt = sourceExt;
 		this.destExt = destExt;
+		this.version = 0;
 	}
 
 	public function convert() {


### PR DESCRIPTION
Adds `version` variable to `Convert`. Allows invalidation of .tmp cache without user involvement when new version is introduced.
Also added `disable_res_cache` define, which ensures that cache is always treated as invalid. Intended use is for people who write their own converts to ease up the development process.
Ref #720 