### PR TITLE
Default letterSpacing to 0

### DIFF
--- a/h2d/HtmlText.hx
+++ b/h2d/HtmlText.hx
@@ -5,6 +5,10 @@ import h2d.Text;
 class HtmlText extends Text {
 
 	public var condenseWhite(default,set) : Bool = true;
+	/**
+		Spacing after <img> tags in pixels.
+	**/
+	public var imageSpacing(default,set):Float = 1;
 
 	var elements : Array<Object> = [];
 	var xPos : Float;
@@ -121,7 +125,7 @@ class HtmlText extends Text {
 				newLine = true;
 			case "img":
 				var i = loadImage(e.get("src"));
-				len = (i == null ? 8 : i.width) + letterSpacing;
+				len = (i == null ? 8 : i.width) + imageSpacing;
 				newLine = false;
 			case "font":
 				for( a in e.attributes() ) {
@@ -384,7 +388,7 @@ class HtmlText extends Text {
 				newLine = false;
 				var i = loadImage(e.get("src"));
 				if( i == null ) i = Tile.fromColor(0xFF00FF, 8, 8);
-				if( realMaxWidth >= 0 && xPos + i.width + letterSpacing + remainingSize(sizes) > realMaxWidth && xPos > 0 ) {
+				if( realMaxWidth >= 0 && xPos + i.width + imageSpacing + remainingSize(sizes) > realMaxWidth && xPos > 0 ) {
 					if( xPos > xMax ) xMax = xPos;
 					xPos = 0;
 					yPos += font.lineHeight + lineSpacing;
@@ -398,7 +402,7 @@ class HtmlText extends Text {
 					b.y = py;
 					elements.push(b);
 				}
-				xPos += i.width + letterSpacing;
+				xPos += i.width + imageSpacing;
 			default:
 			}
 			for( child in e )
@@ -445,6 +449,13 @@ class HtmlText extends Text {
 				}
 			}
 		}
+	}
+
+	function set_imageSpacing(s) {
+		if (imageSpacing == s) return s;
+		imageSpacing = s;
+		rebuild();
+		return s;
 	}
 
 	override function set_textColor(c) {

--- a/h2d/Text.hx
+++ b/h2d/Text.hx
@@ -39,7 +39,7 @@ class Text extends Drawable {
 		super(parent);
 		this.font = font;
 		textAlign = Left;
-		letterSpacing = 1;
+		letterSpacing = 0;
 		lineSpacing = 0;
 		text = "";
 		textColor = 0xFFFFFF;

--- a/h2d/domkit/BaseComponents.hx
+++ b/h2d/domkit/BaseComponents.hx
@@ -440,7 +440,7 @@ class TextComp extends DrawableComp implements domkit.Component.ComponentDecl<h2
 
 	@:p var text : String = "";
 	@:p(font) var font : h2d.Font;
-	@:p var letterSpacing = 1;
+	@:p var letterSpacing = 0;
 	@:p var lineSpacing = 0;
 	@:p(none) var maxWidth : Null<Int>;
 	@:p var textAlign : h2d.Text.Align = Left;

--- a/hxd/fmt/bfnt/FontParser.hx
+++ b/hxd/fmt/bfnt/FontParser.hx
@@ -93,7 +93,7 @@ class FontParser {
 					var r = c.att.rect.split(" ");
 					var o = c.att.offset.split(" ");
 					var t = tile.sub(Std.parseInt(r[0]), Std.parseInt(r[1]), Std.parseInt(r[2]), Std.parseInt(r[3]), Std.parseInt(o[0]), Std.parseInt(o[1]));
-					var fc = new h2d.Font.FontChar(t, Std.parseInt(c.att.width) - 1);
+					var fc = new h2d.Font.FontChar(t, Std.parseInt(c.att.width));
 					var code = parseCode(c.att.code);
 					for( k in c.elements ){
 						var next = parseCode(k.att.id);

--- a/hxd/fs/Convert.hx
+++ b/hxd/fs/Convert.hx
@@ -187,6 +187,7 @@ class ConvertFNT2BFNT extends Convert {
 		// Fake tile create subs before discarding the font.
 		emptyTile = @:privateAccess new h2d.Tile(null, 0, 0, 0, 0, 0, 0);
 		super("fnt", "bfnt");
+		version = 1;
 	}
 
 	override public function convert()


### PR DESCRIPTION
* Defaults `Text.letterSpacing` to 0
* Invalidates all bitmap fonts (since we can't detect which one is affected)
* Revert weird hotfix from 2014.
* Added `HtmlText.imageSpacing` (defaults to 1)

There was one particular part I missed when pitching the change. HtmlText uses letterSpacing to pad `<img>` tiles. Hence - introduced `HtmlText.imageSpacing` which remains defaulted to 1.

Closes #720