### PR TITLE
Cursor fixes

### DIFF
--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -216,6 +216,9 @@ class System {
 					var pixels = frame.getPixels();
 					pixels.convert(BGRA);
 					#if hlsdl
+					if (c.offsetX < 0 || c.offsetX >= pixels.width || c.offsetY < 0 || c.offsetY >= pixels.height) {
+						throw "SDL2 does not allow creation of cursors with offset outside of cursor image bounds.";
+					}
 					var surf = sdl.Surface.fromBGRA(pixels.bytes, pixels.width, pixels.height);
 					c.alloc.push(sdl.Cursor.create(surf, c.offsetX, c.offsetY));
 					surf.free();

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -171,8 +171,10 @@ class Window {
 				#end
 			case Enter:
 				#if hldx
-				// reset cursor to default
-				dx.Cursor.createSystem(Arrow).set();
+				// Restore cursor
+				var cur = @:privateAccess hxd.System.currentNativeCursor;
+				@:privateAccess hxd.System.currentNativeCursor = null;
+				hxd.System.setNativeCursor(cur);
 				#end
 				event(new Event(EOver));
 			case Leave:

--- a/samples/Cursor.hx
+++ b/samples/Cursor.hx
@@ -36,6 +36,7 @@ class Cursor extends SampleApp {
 			var i = new h2d.Interactive(120, 20, s2d);
 			var tf = new h2d.Text(hxd.res.DefaultFont.get(), i);
 			tf.text = c.getName();
+			tf.dropShadow = { dx: 1, dy: 1, color: 0, alpha: 1 };
 			tf.x = 5;
 			i.x = 0;
 			i.y = pos++ * 20;
@@ -62,6 +63,9 @@ class Cursor extends SampleApp {
 		// It's possible to override default cursors by custom ones by setting
 		// `hxd.System.setCursor` function.
 		// Useful when game utilizes stylized cursors for everything.
+
+		// HLSDL note: Cursor offsetX and offsetY should remain inside frame bounds.
+		// This is a limitation of SDL (most likely for portability reasons).
 
 		var doOverride = false;
 		var defOverride = new hxd.BitmapData(10, 10);


### PR DESCRIPTION
* Throw an error when cursor offset is out of bounds on SDL
* Fix custom default cursor not restoring on DX
Happens if you have custom cursor as Default, after leaving window and returning it turns to OS default cursor instead of custom one.
* Add SDL note in cursor sample.
* Improve text visibility in cursor sample.
Random colors sometimes make text very hard to read.

Resolves #650