### PR TITLE
Implement async audio decoder

### DIFF
--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -607,7 +607,7 @@ class Manager {
 
 	#else
 	inline function progressiveDecodeBuffer( s : Source, snd : hxd.res.Sound, start : Int ) {
-		decodeStreamBuffer(s, snd, start, Math.ceil(STREAM_BUFFER_SAMPLE_COUNT / BUFFER_STREAM_SPLIT));
+		return decodeStreamBuffer(s, snd, start, Math.ceil(STREAM_BUFFER_SAMPLE_COUNT / BUFFER_STREAM_SPLIT));
 	}
 	#end
 


### PR DESCRIPTION
* Based off `target.threaded` compiler flag enables async buffer decoder.
* Can be forced to use non-threaded mode with `-D snd_sync` flag.
* Implementation does not affect short sounds, they are still decoded in main thread. 
* I'm not sure about dispose code and in general how clean the implementation is, as I'm not very adept with multithreaded programming.