### PR TITLE
updates to Makefile

### DIFF
--- a/tools/mikktspace/Makefile
+++ b/tools/mikktspace/Makefile
@@ -4,11 +4,11 @@ HASHLINK=/usr/local/include
 endif
 
 ifndef HASHLINK_BIN
-HASHLINK=/usr/local/lib
+HASHLINK_BIN=/usr/local/lib
 endif
 
 all: codegen
-	gcc -I $HASHLINK -I out out/main.c -lhl -L${HASHLINK_BIN}/fmt.hdll -o mikktspace
+	gcc -I ${HASHLINK} -I out out/main.c ${HASHLINK_BIN}/libhl.dylib ${HASHLINK_BIN}/fmt.hdll -o mikktspace
 
 codegen:
 	haxe mikktspace.hxml -D no-compilation


### PR DESCRIPTION
where it use to say
```
ifndef HASHLINK_BIN
HASHLINK=/usr/local/lib
endif
```
I've updated this to:
```
ifndef HASHLINK_BIN
HASHLINK_BIN=/usr/local/lib
endif
```
I'm assuming this was a typo? but could be wrong.

I've also added some missing brackets that should be around vars
eg:
-I ${HASHLINK}
instead of 
-I $HASHLINK

and finally when this section was used `-lhl -L${HASHLINK_BIN}/fmt.hdll`
I get the following error:
```
warning: -L path {HASHLINK_BIN}'/fmt.hdll' is not a directory
Undefined symbols for architecture x86_64:
  "_fmt_compute_mikkt_tangents", referenced from:
      _hl_Mikktspace_compute in main-90159c.o
      _hl_functions_ptrs in main-90159c.o
ld: symbol(s) not found for architecture x86_64
```

amended this to what was defined in the shell script seems to resolve it:
```
gcc -I ${HASHLINK} -I out out/main.c ${HASHLINK_BIN}/libhl.dylib ${HASHLINK_BIN}/fmt.hdll -o mikktspace
```
swap -lhl -L${HASHLINK_BIN}/fmt.hdll for ${HASHLINK_BIN}/libhl.dylib ${HASHLINK_BIN}/fmt.hdll