### PR TITLE
Fix pixel bleeding with center scaleMode align

### DIFF
--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -241,7 +241,7 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 					offsetX = -((engine.width - width * zoom) / (2 * zoom));
 					viewportX = (engine.width - width * zoom) / zoom;
 				default:
-					offsetX = 0;
+					offsetX = -(((engine.width - width * zoom) / 2) % 1.)*.5;
 					viewportX = (engine.width - width * zoom) / (2 * zoom);
 			}
 
@@ -254,7 +254,7 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 					offsetY = -((engine.height - height * zoom) / (2 * zoom));
 					viewportY = (engine.height - height * zoom) / zoom;
 				default:
-					offsetY = 0;
+					offsetY = -(((engine.height - height * zoom) / 2) % 1.)*.5;
 					viewportY = (engine.height - height * zoom) / (2 * zoom);
 			}
 		}


### PR DESCRIPTION
Fixes pixel bleeding with some window sizes when using scaleMode with center alignment.
Before:
![image](https://user-images.githubusercontent.com/1061373/71787863-c54c6080-302d-11ea-86a3-35c11a08f8a4.png)
After:
![image](https://user-images.githubusercontent.com/1061373/71787869-d301e600-302d-11ea-94df-5c3083012019.png)
