### PR TITLE
Implement Mask.scroll

### DIFF
--- a/samples/Mask.hx
+++ b/samples/Mask.hx
@@ -1,12 +1,20 @@
 class Mask extends hxd.App {
 
 	var obj : h2d.Object;
+	var mask : h2d.Mask;
 	var time : Float = 0.;
 
 	override function init() {
-		var mask = new h2d.Mask(160, 160, s2d);
+		mask = new h2d.Mask(160, 160, s2d);
 		mask.x = 200;
 		mask.y = 150;
+
+		// Mask-sized rectangle to display mask boundaries
+		// and make scroll movement more apparent.
+		new h2d.Bitmap(h2d.Tile.fromColor(0x222222, mask.width, mask.height), mask);
+		// Limit scroll
+		mask.scrollBounds = h2d.col.Bounds.fromValues(-mask.width/2, -mask.height/2,mask.width*2, mask.height*2);
+
 		obj = new h2d.Object(mask);
 		obj.x = obj.y = 80;
 		for( i in 0...10 ) {
@@ -15,11 +23,20 @@ class Mask extends hxd.App {
 			b.x = Std.random(200) - 100;
 			b.y = Std.random(200) - 100;
 		}
+		var info = new h2d.Text(hxd.res.DefaultFont.get(), s2d);
+		info.setPosition(5, 5);
+		info.text = "Arrows: move scrollX/Y\nSpace: reset scroll to 0,0";
+
 	}
 
 	override function update(dt:Float) {
 		time += dt;
 		obj.rotation += 0.6 * dt;
+		if (hxd.Key.isDown(hxd.Key.LEFT)) mask.scrollX -= 100 * dt;
+		if (hxd.Key.isDown(hxd.Key.RIGHT)) mask.scrollX += 100 * dt;
+		if (hxd.Key.isDown(hxd.Key.UP)) mask.scrollY -= 100 * dt;
+		if (hxd.Key.isDown(hxd.Key.DOWN)) mask.scrollY += 100 * dt;
+		if (hxd.Key.isReleased(hxd.Key.SPACE)) mask.scrollTo(0, 0);
 	}
 
 	static function main() {


### PR DESCRIPTION
* Adds `scrollX` and `scrollY` to Mask, allowing to scroll the contents.
* Adds wrappers `scrollTo` and `scrollBy` as shortcuts.
* Updates Mask sample to showcase scroll feature.

Ref #606; (Does not resolve actual issue, but related)