### PR TITLE
Mask.maskWith API / h2d.Flow.overflow enum

### DIFF
--- a/h2d/Flow.hx
+++ b/h2d/Flow.hx
@@ -14,6 +14,25 @@ enum FlowLayout {
 	Stack;
 }
 
+enum FlowOverflow {
+	/**
+		Children larger than `maxWidth`/`maxHeight` will expand the flow size.
+	**/
+	Expand;
+	/**
+		Limits the bounds reported by the flow using `maxWidth` or `maxHeight`, if set.
+		This is means children larger than max size will draw outside of their parent bounds.
+	**/
+	Limit;
+	/**
+		Limits the bounds reported by the flow using `maxWidth` or `maxHeight`, if set.
+		Compared to `Limit` - Flow will mask out children that are outside of Flow bounds.
+	**/
+	Hidden;
+	// TODO: Scroll overflow, see #606
+	//Scroll;
+}
+
 @:allow(h2d.Flow)
 class FlowProperties {
 
@@ -98,7 +117,7 @@ class Flow extends Object {
 	/**
 		Enabling overflow will treat maxWidth/maxHeight and lineHeight/colWidth constraints as absolute : bigger elements will overflow instead of expanding the limit.
 	**/
-	public var overflow(default, set) : Bool = false;
+	public var overflow(default, set) : FlowOverflow = Expand;
 
 	/**
 		Will set all padding values at the same time.
@@ -499,6 +518,23 @@ class Flow extends Object {
 		super.sync(ctx);
 	}
 
+	override function drawRec(ctx:RenderContext)
+	{
+		if ( overflow == Hidden ) {
+			if ( posChanged ) {
+				calcAbsPos();
+				for ( c in children )
+					c.posChanged = true;
+				posChanged = false;
+			}
+			Mask.maskWith(ctx, this, hxd.Math.imax(outerWidth, maxWidth), hxd.Math.imax(outerHeight, maxHeight), 0, 0);
+			super.drawRec(ctx);
+			Mask.unmask(ctx);
+		} else {
+			super.drawRec(ctx);
+		}
+	}
+
 	function set_maxWidth(w) {
 		if( maxWidth == w )
 			return w;
@@ -681,7 +717,7 @@ class Flow extends Object {
 			inline function alignLine( maxIndex ) {
 				if( maxLineHeight < minLineHeight )
 					maxLineHeight = minLineHeight;
-				else if( overflow && minLineHeight != 0 )
+				else if( overflow != Expand && minLineHeight != 0 )
 					maxLineHeight = minLineHeight;
 				for( i in lastIndex...maxIndex ) {
 					var p = propAt(i);
@@ -826,7 +862,7 @@ class Flow extends Object {
 			inline function alignLine( maxIndex ) {
 				if( maxColWidth < minColWidth )
 					maxColWidth = minColWidth;
-				else if( overflow && minColWidth != 0 )
+				else if( overflow != Expand && minColWidth != 0 )
 					maxColWidth = minColWidth;
 				for( i in lastIndex...maxIndex ) {
 					var p = propAt(i);
@@ -991,9 +1027,9 @@ class Flow extends Object {
 
 			var xmin = paddingLeft + borderWidth;
 			var ymin = paddingTop + borderHeight;
-			var xmax = if(realMaxWidth > 0 && overflow) Math.floor(realMaxWidth - (paddingRight + borderWidth))
+			var xmax = if(realMaxWidth > 0 && overflow != Expand) Math.floor(realMaxWidth - (paddingRight + borderWidth))
 				else hxd.Math.imax(xmin + maxChildW, realMinWidth - (paddingRight + borderWidth));
-			var ymax = if(realMaxWidth > 0 && overflow) Math.floor(realMaxHeight - (paddingBottom + borderHeight))
+			var ymax = if(realMaxWidth > 0 && overflow != Expand) Math.floor(realMaxHeight - (paddingBottom + borderHeight))
 				else hxd.Math.imax(ymin + maxChildH, realMinHeight - (paddingBottom + borderHeight));
 			cw = xmax + paddingRight + borderWidth;
 			ch = ymax + paddingBottom + borderHeight;
@@ -1035,7 +1071,7 @@ class Flow extends Object {
 
 		if( realMinWidth >= 0 && cw < realMinWidth ) cw = realMinWidth;
 		if( realMinHeight >= 0 && ch < realMinHeight ) ch = realMinHeight;
-		if( overflow ) {
+		if( overflow != Expand ) {
 			if( isConstraintWidth && cw > maxTotWidth ) cw = maxTotWidth;
 			if( isConstraintHeight && ch > maxTotHeight ) ch = maxTotHeight;
 		}

--- a/h2d/Mask.hx
+++ b/h2d/Mask.hx
@@ -7,6 +7,10 @@ class Mask extends Object {
 	static var renderZoneStack:Array<RenderZoneStack> = [];
 	static var renderZoneCaret:Int = 0;
 
+	/**
+		Masks render zone based off object position and given dimensions.
+		Should call `Mask.unmask()` afterwards.
+	**/
 	@:access(h2d.RenderContext)
 	public static function maskWith( ctx : RenderContext, object : Object, width : Int, height : Int, scrollX : Float = 0, scrollY : Float = 0) {
 
@@ -48,6 +52,9 @@ class Mask extends Object {
 		ctx.setRenderZone(x1, y1, x2-x1, y2-y1);
 	}
 
+	/**
+		Unmasks prviously masked area from `Mask.maskWith`.
+	**/
 	public static function unmask( ctx : RenderContext ) {
 		if (renderZoneCaret == 0) throw "Too many unmask()";
 		var inf = renderZoneStack[--renderZoneCaret];

--- a/h2d/Mask.hx
+++ b/h2d/Mask.hx
@@ -1,11 +1,7 @@
 package h2d;
 
-private typedef RenderZoneStack = { hasRZ:Bool, x:Float, y:Float, w:Float, h:Float };
 
 class Mask extends Object {
-
-	static var renderZoneStack:Array<RenderZoneStack> = [];
-	static var renderZoneCaret:Int = 0;
 
 	/**
 		Masks render zone based off object position and given dimensions.
@@ -33,37 +29,16 @@ class Mask extends Object {
 			y2 = tmp;
 		}
 
-		var inf = renderZoneStack[renderZoneCaret++];
-		if ( inf == null ) {
-			inf = { hasRZ: ctx.hasRenderZone, x: ctx.renderX, y: ctx.renderY, w: ctx.renderW, h: ctx.renderH };
-			renderZoneStack[renderZoneCaret - 1] = inf;
-		}
-		else if ( ctx.hasRenderZone ) {
-			inf.hasRZ = true;
-			inf.x = ctx.renderX;
-			inf.y = ctx.renderY;
-			inf.w = ctx.renderW;
-			inf.h = ctx.renderH;
-		} else {
-			inf.hasRZ = false;
-		}
-
 		ctx.flush();
-		ctx.setRenderZone(x1, y1, x2-x1, y2-y1);
+		ctx.pushRenderZone(x1, y1, x2-x1, y2-y1);
 	}
 
 	/**
 		Unmasks prviously masked area from `Mask.maskWith`.
 	**/
 	public static function unmask( ctx : RenderContext ) {
-		if (renderZoneCaret == 0) throw "Too many unmask()";
-		var inf = renderZoneStack[--renderZoneCaret];
 		ctx.flush();
-		if (inf.hasRZ) {
-			ctx.setRenderZone(inf.x, inf.y, inf.w, inf.h);
-		} else {
-			ctx.clearRenderZone();
-		}
+		ctx.popRenderZone();
 	}
 
 	public var width : Int;

--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -287,7 +287,7 @@ class TextInput extends Text {
 	override function draw(ctx:RenderContext) {
 		if( inputWidth != null ) {
 			var h = localToGlobal(new h2d.col.Point(inputWidth, font.lineHeight));
-			ctx.setRenderZone(absX, absY, h.x - absX, h.y - absY);
+			ctx.pushRenderZone(absX, absY, h.x - absX, h.y - absY);
 		}
 
 		if( cursorIndex >= 0 && (text != cursorText || cursorIndex != cursorXIndex) ) {
@@ -331,7 +331,7 @@ class TextInput extends Text {
 		}
 
 		if( inputWidth != null )
-			ctx.clearRenderZone();
+			ctx.popRenderZone();
 	}
 
 	public function focus() {

--- a/samples/Flows.hx
+++ b/samples/Flows.hx
@@ -436,7 +436,7 @@ class Flows extends hxd.App {
 			flow.maxWidth = 350;
 			flow.minHeight = flow.maxHeight = 350;
 			flow.layout = Stack;
-			flow.overflow = true;
+			flow.overflow = Limit;
 			currentFlows.push(flow);
 
 			var sub = new h2d.Flow(flow);

--- a/samples/Mask.hx
+++ b/samples/Mask.hx
@@ -1,13 +1,18 @@
+import h2d.RenderContext;
+import h2d.Object;
+
 class Mask extends hxd.App {
 
 	var obj : h2d.Object;
 	var mask : h2d.Mask;
 	var time : Float = 0.;
 
+	var apiMask : MaskWithSample;
+
 	override function init() {
 		mask = new h2d.Mask(160, 160, s2d);
-		mask.x = 200;
-		mask.y = 150;
+		mask.x = 20;
+		mask.y = 50;
 
 		// Mask-sized rectangle to display mask boundaries
 		// and make scroll movement more apparent.
@@ -27,11 +32,17 @@ class Mask extends hxd.App {
 		info.setPosition(5, 5);
 		info.text = "Arrows: move scrollX/Y\nSpace: reset scroll to 0,0";
 
+		// Content masking also possible with advanced `Mask.maskWith` and `Mask.unmask` methods.
+		apiMask = new MaskWithSample(s2d);
+		apiMask.setPosition(200, 50);
 	}
 
 	override function update(dt:Float) {
 		time += dt;
 		obj.rotation += 0.6 * dt;
+		apiMask.sx = Math.cos(time) * 100 + 100;
+		apiMask.sy = Math.sin(time) * 100 + 100;
+
 		if (hxd.Key.isDown(hxd.Key.LEFT)) mask.scrollX -= 100 * dt;
 		if (hxd.Key.isDown(hxd.Key.RIGHT)) mask.scrollX += 100 * dt;
 		if (hxd.Key.isDown(hxd.Key.UP)) mask.scrollY -= 100 * dt;
@@ -42,6 +53,28 @@ class Mask extends hxd.App {
 	static function main() {
 		hxd.Res.initEmbed();
 		new Mask();
+	}
+
+}
+
+class MaskWithSample extends Object {
+
+	public var sx:Float = 0;
+	public var sy:Float = 0;
+
+	public function new(?parent:Object) {
+		super(parent);
+		new h2d.Bitmap(hxd.Res.hxlogo.toTile(), this);
+	}
+
+	override function drawRec(ctx:RenderContext)
+	{
+		// Masking with advanced API allows to mask contents with objects that cannot use Mask as intermediary or extend from it.
+		// For practical usage sample see h2d.Flow Hidden overflow mode.
+		h2d.Mask.maskWith(ctx, this, 50, 50, sx, sy);
+		super.drawRec(ctx);
+		// Unmask should be called after `maskWith` in order to restore previous renderZone state.
+		h2d.Mask.unmask(ctx);
 	}
 
 }


### PR DESCRIPTION
Ref: #606 
* Implemented `Mask.maskWith` and `Mask.unmask` methods. 
Had to use static stack to hold renderZone state, otherwise using that API would break mask-in-mask (and most likely filters). Alternatively I would say it's possible to change `setRenderZone` to `pushRenderZone(x, y, w, h, inherit)` stack, allowing for more robust render-zone handling. (With inherit = true, new renderZone would be clipped by existing renderZone)
* Changed `h2d.Flow.overflow` to an enum
* Implemented Hidden overflow.
* Added showcase of advanced masking to Mask sample.

I'm not touching `FlowOverflow.Scroll`, too much have to be accounted, I'll leave it to the person who actually assigned to the task. ;)