### PR TITLE
Fix incorrect pop filter on offscreen object

### DIFF
--- a/h2d/Object.hx
+++ b/h2d/Object.hx
@@ -698,7 +698,10 @@ class Object #if (domkit && !domkit_heaps) implements domkit.Model<h2d.Object> #
 		var width = Math.ceil(total.xMax - xMin - 1e-10);
 		var height = Math.ceil(total.yMax - yMin - 1e-10);
 
-		if( width <= 0 || height <= 0 || total.xMax < total.xMin ) return;
+		if( width <= 0 || height <= 0 || total.xMax < total.xMin ) {
+			ctx.popFilter();
+			return;
+		}
 
 		var t = ctx.textures.allocTarget("filterTemp", width, height, false);
 		ctx.pushTarget(t, xMin, yMin, width, height);


### PR DESCRIPTION
While working on DKH we encountered a bug.
If an object with a filter is offscreen the RenderContext keep pushing the filter without ever poping it, resulting in a weird behavior and a leak.