### PR TITLE
feat: adding extended support for instancing also in webgl1 devices s…

### DIFF
--- a/h3d/impl/Driver.hx
+++ b/h3d/impl/Driver.hx
@@ -93,6 +93,10 @@ enum Feature {
 		Supports rendering in wireframe mode.
 	*/
 	Wireframe;
+	/*
+		Supports instanced rendering
+	*/
+	InstancedRendering;
 }
 
 enum QueryKind {

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -12,8 +12,8 @@ private typedef GL = js.html.webgl.GL;
 private extern class GL2 extends js.html.webgl.GL {
 	// webgl2
 	function drawBuffers( buffers : Array<Int> ) : Void;
-	dynamic function vertexAttribDivisor( index : Int, divisor : Int ) : Void;
-	dynamic function drawElementsInstanced( mode : Int, count : Int, type : Int, offset : Int, instanceCount : Int) : Void;
+	function vertexAttribDivisor( index : Int, divisor : Int ) : Void;
+	function drawElementsInstanced( mode : Int, count : Int, type : Int, offset : Int, instanceCount : Int) : Void;
 	function getUniformBlockIndex( p : Program, name : String ) : Int;
 	function bindBufferBase( target : Int, index : Int, buffer : js.html.webgl.Buffer ) : Void;
 	function uniformBlockBinding( p : Program, blockIndex : Int, blockBinding : Int ) : Void;
@@ -238,8 +238,8 @@ class GlDriver extends Driver {
 		// We need to get instanced rendering by it's ANGLE extension if we are using webgl1
 		if(hasFeature(InstancedRendering) && glES < 3) {
 			final extension:js.html.webgl.extension.ANGLEInstancedArrays =  cast gl.getExtension("ANGLE_instanced_arrays");
-			gl.vertexAttribDivisor = extension.vertexAttribDivisorANGLE;
-			gl.drawElementsInstanced = extension.drawElementsInstancedANGLE;
+			Reflect.setField(gl,"vertexAttribDivisor",extension.vertexAttribDivisorANGLE);
+			Reflect.setField(gl,"drawElementsInstanced",extension.drawElementsInstancedANGLE);
 		}
 
 		// setup shader optim

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -237,7 +237,7 @@ class GlDriver extends Driver {
 
 		// We need to get instanced rendering by it's ANGLE extension if we are using webgl1
 		if(hasFeature(InstancedRendering) && glES < 3) {
-			final extension:js.html.webgl.extension.ANGLEInstancedArrays =  cast gl.getExtension("ANGLE_instanced_arrays");
+			var extension:js.html.webgl.extension.ANGLEInstancedArrays =  cast gl.getExtension("ANGLE_instanced_arrays");
 			Reflect.setField(gl,"vertexAttribDivisor",extension.vertexAttribDivisorANGLE);
 			Reflect.setField(gl,"drawElementsInstanced",extension.drawElementsInstancedANGLE);
 		}

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -12,8 +12,8 @@ private typedef GL = js.html.webgl.GL;
 private extern class GL2 extends js.html.webgl.GL {
 	// webgl2
 	function drawBuffers( buffers : Array<Int> ) : Void;
-	function vertexAttribDivisor( index : Int, divisor : Int ) : Void;
-	function drawElementsInstanced( mode : Int, count : Int, type : Int, offset : Int, instanceCount : Int) : Void;
+	dynamic function vertexAttribDivisor( index : Int, divisor : Int ) : Void;
+	dynamic function drawElementsInstanced( mode : Int, count : Int, type : Int, offset : Int, instanceCount : Int) : Void;
 	function getUniformBlockIndex( p : Program, name : String ) : Int;
 	function bindBufferBase( target : Int, index : Int, buffer : js.html.webgl.Buffer ) : Void;
 	function uniformBlockBinding( p : Program, blockIndex : Int, blockBinding : Int ) : Void;
@@ -234,6 +234,14 @@ class GlDriver extends Driver {
 		#if js
 		// make sure to enable extensions
 		makeFeatures();
+
+		// We need to get instanced rendering by it's ANGLE extension if we are using webgl1
+		if(hasFeature(InstancedRendering) && glES < 3) {
+			final extension:js.html.webgl.extension.ANGLEInstancedArrays =  cast gl.getExtension("ANGLE_instanced_arrays");
+			gl.vertexAttribDivisor = extension.vertexAttribDivisorANGLE;
+			gl.drawElementsInstanced = extension.drawElementsInstancedANGLE;
+		}
+
 		// setup shader optim
 		hxsl.SharedShader.UNROLL_LOOPS = !hasFeature(ShaderModel3);
 		#else
@@ -1562,6 +1570,9 @@ class GlDriver extends Driver {
 
 		case MultipleRenderTargets:
 			mrtExt != null || (mrtExt = gl.getExtension('WEBGL_draw_buffers')) != null;
+			
+		case InstancedRendering:
+			return (glES >= 3) ? true : gl.getExtension("ANGLE_instanced_arrays") != null;
 
 		default:
 			false;


### PR DESCRIPTION
Since instanced rendering is only supported trough ANGLE-extension there needs to be a check for this.

ANGLE_instanced_arrays is supported by 98% of mobile devices and is directly compatible with the core version for webgl2. 

This update uses this and makes sure devices that supports instancing gets it even if they are running webgl1 context.