### PR TITLE
Fixed JS version of hxd.File.browse on Chrome

### DIFF
--- a/hxd/File.hx
+++ b/hxd/File.hx
@@ -162,6 +162,7 @@ class File {
 					}
 				}
 				onSelect(b);
+				input.remove();
 			}
 			input.click();
 		#else

--- a/hxd/File.hx
+++ b/hxd/File.hx
@@ -117,14 +117,23 @@ class File {
 			};
 			onSelect(b);
 		#elseif js
-			var input = js.Browser.document.createElement("input");
+			var input : js.html.InputElement = cast js.Browser.document.getElementById("heapsBrowserInput");
+			if( input==null ) {
+				input = cast js.Browser.document.createElement("input");
+				input.setAttribute("id","heapsBrowserInput");
+				js.Browser.document.body.appendChild(input);
+			}
 			input.setAttribute("type","file");
+			input.style.display = "none";
 			if( options.fileTypes!=null ) {
 				var extensions = [];
 				for(ft in options.fileTypes)
 					for(e in ft.extensions)
 						extensions.push("."+e);
 				input.setAttribute("accept",extensions.join(","));
+			}
+			input.onclick = function(e) {
+				input.value = null;
 			}
 			input.onchange = function(e) {
 				var file : js.html.File = e.target.files[0];


### PR DESCRIPTION
For some obscure reason, the method used to upload a file to an app on Chrome didn't work sometimes (the Open window would pop-up, but the onChange callback wasn't called).

The new version adds the <input> element to the actual <body> and it stays there, hidden. 