### PR TITLE
Only display stacktraces in a window on Windows platform

### DIFF
--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -158,10 +158,11 @@ class System {
 		#if usesys
 		haxe.System.reportError(err + stack);
 		#else
+		Sys.println(err + stack);
+
 		if ( Sys.systemName() != 'Windows' )
 			return;
 
-		Sys.println(err + stack);
 		if( dismissErrors )
 			return;
 

--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -158,7 +158,7 @@ class System {
 		#if usesys
 		haxe.System.reportError(err + stack);
 		#else
-		Sys.println(err + stack);
+		Sys.stderr().writeString(err + stack + "\n");
 
 		if ( Sys.systemName() != 'Windows' )
 			return;

--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -158,6 +158,9 @@ class System {
 		#if usesys
 		haxe.System.reportError(err + stack);
 		#else
+		if ( Sys.systemName() != 'Windows' )
+			return;
+
 		Sys.println(err + stack);
 		if( dismissErrors )
 			return;


### PR DESCRIPTION
Consider the following incorrect program using heaps:

```haxe
class Main extends hxd.App {
  static var b : Array<Int>;

  static public function main():Void {
    //b = new Array<Int>();
    b.push(42);
  }
}
```

That program tries to add element to an array that wasn't allocated, which is obviously incorrect. Compiling and running under Linux causes the program to hang in an infinite loop:

```
$ haxe -main Main -lib heaps -cp . -hl foo.hl
$ hl foo.hl
Null access
Called from $Main.main (Main.hx line 6)
```

The problem is in the [System.reportError](https://github.com/HeapsIO/heaps/blob/2b3efb27a55dd17901d3be47b146011d6bf763d8/hxd/System.hl.hx#L155) function that attempts to display a stacktrace in a window. However, UI subsystem is not implemented in hashlink on Linux ([see here](https://github.com/HaxeFoundation/hashlink/blob/master/libs/ui/ui_stub.c)). In particular, heaps expects that a [UI loop will eventually return a `Quit`](https://github.com/HeapsIO/heaps/blob/2b3efb27a55dd17901d3be47b146011d6bf763d8/hxd/System.hl.hx#L183):

```
while( hl.UI.loop(true) != Quit )
    timeoutTick();
```

but that will never be the case on Linux, since the [Linux UI stub always returns `HandleMessage`](https://github.com/HaxeFoundation/hashlink/blob/master/libs/ui/ui_stub.c#L39) (see [here](https://github.com/HaxeFoundation/haxe/blob/4.0.5/std/hl/UI.hx#L123) for definition of `LoopResult`).

```
HL_PRIM int HL_NAME(ui_loop)( bool blocking ) {
  return 1;
}
```

**Solution**: only create a UI window on Windows platform. With this patch running `hl foo.hl` on Linux produces a stacktrace on the console and terminates normally:

```
$ hl foo.hl
Uncaught exception: Null access
Called from $Main.main(Main.hx:14)
Called from fun$3997(?:1)
```

Behaviour on Windows should remain unchanged.