### PR TITLE
Marked Interactive.cursor as nullable

### DIFF
--- a/h2d/Interactive.hx
+++ b/h2d/Interactive.hx
@@ -14,7 +14,7 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 	/**
 		Cursor used when Interactive is under mouse cursor ( default : Button )
 	**/
-	public var cursor(default,set) : hxd.Cursor;
+	public var cursor(default,set) : Null<hxd.Cursor>;
 	/**
 		Should object collision be in rectangle or ellipse form? Ignored if `shape` is set.
 	**/

--- a/h3d/scene/Interactive.hx
+++ b/h3d/scene/Interactive.hx
@@ -14,7 +14,7 @@ class Interactive extends Object implements hxd.SceneEvents.Interactive {
 	**/
 	@:s public var priority : Int;
 
-	public var cursor(default,set) : hxd.Cursor;
+	public var cursor(default,set) : Null<hxd.Cursor>;
 	/**
 		Set the default `cancel` mode (see `hxd.Event`), default to false.
 	**/


### PR DESCRIPTION
The Interactive.cursor is nullable, as it's actually supported in the SceneEvents.selectCursor . A nice hidden but useful feature ;)