### PR TITLE
Feat: Add defaultUnit methods to Cylinder and Disc

### DIFF
--- a/h3d/prim/Cylinder.hx
+++ b/h3d/prim/Cylinder.hx
@@ -44,4 +44,22 @@ class Cylinder extends Quads {
 		}
 	}
 
+	/**
+	 * Get a default unit Cylinder with 
+	 * segs = 16, ray = 0.5, height = 1.0, centered = false
+	 * and add UVs to it. If it has not be cached, it is cached and subsequent
+	 * calls to this method will return Cylinder from cache.
+	 * @param segs Optional number of segments of the cylinder, default 16
+	 */
+	public static function defaultUnitCylinder(segs : Int = 16) {
+		var engine = h3d.Engine.getCurrent();
+		var c : Cylinder = @:privateAccess engine.resCache.get(Cylinder);
+		if( c != null )
+			return c;
+		c = new h3d.prim.Cylinder(segs, 0.5);
+		c.addUVs();
+		@:privateAccess engine.resCache.set(Cylinder, c);
+		return c;
+	}
+
 }

--- a/h3d/prim/Disc.hx
+++ b/h3d/prim/Disc.hx
@@ -32,4 +32,21 @@ class Disc extends Polygon {
 		uvs.push( new UV( 0.5, 0.5 ) );
 	}
 
+	/**
+	 * Get a default unit Disc with 
+	 * radius = 0.5, segments = 8, thetaStart = 0.0, thetaLength = Math.PI * 2
+	 * and add UVs to it. If it has not be cached, it is cached and subsequent
+	 * calls to this method will return Disc from cache.
+	 */
+	public static function defaultUnitDisc() {
+		var engine = h3d.Engine.getCurrent();
+		var d : Disc = @:privateAccess engine.resCache.get(Disc);
+		if( d != null )
+			return d;
+		d = new h3d.prim.Disc();
+		d.addUVs();
+		@:privateAccess engine.resCache.set(Disc, d);
+		return d;
+	}
+
 }


### PR DESCRIPTION
Add methods to Cylinder and Disc to get a default unit to be api consistent with Cube and Sphere.