### PR TITLE
Add global.time to 2D shader globals

### DIFF
--- a/h2d/RenderContext.hx
+++ b/h2d/RenderContext.hx
@@ -90,6 +90,7 @@ class RenderContext extends h3d.impl.RenderContext {
 		curWidth = scene.width;
 		curHeight = scene.height;
 		manager.globals.set("time", time);
+		manager.globals.set("global.time", time);
 		// todo : we might prefer to auto-detect this by running a test and capturing its output
 		baseShader.pixelAlign = #if flash true #else false #end;
 		baseShader.halfPixelInverse.set(0.5 / engine.width, 0.5 / engine.height);


### PR DESCRIPTION
Allows to use AnimatedTexture, UVAnim and UVScroll shaders in 2D context, since they rely on `global.time`.
Alternative solution is to change `time` to `global.time` and change shaders that use it, but it's a clear breaking change and I'm not sure if other people rely on 2D time global.