### PR TITLE
Add Save.savePath

### DIFF
--- a/hxd/Save.hx
+++ b/hxd/Save.hx
@@ -33,7 +33,9 @@ class Save {
 				haxe.io.Path.normalize(savePath + "/" + name + ".sav");
 		#if sys
 		// Ensure directory path exists.
-		sys.FileSystem.createDirectory(haxe.io.Path.directory(path));
+		var dir = haxe.io.Path.directory(path);
+		if (!sys.FileSystem.exists(dir))
+			sys.FileSystem.createDirectory(dir);
 		#end
 		return path;
 	}

--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -97,6 +97,7 @@ class System {
 		var size = haxe.macro.Compiler.getDefine("windowSize");
 		var title = haxe.macro.Compiler.getDefine("windowTitle");
 		var fixed = haxe.macro.Compiler.getDefine("windowFixed") == "1";
+		var savePath = haxe.macro.Compiler.getDefine("savePath");
 		if( title == null )
 			title = "";
 		if( size != null ) {
@@ -104,6 +105,7 @@ class System {
 			width = Std.parseInt(p[0]);
 			height = Std.parseInt(p[1]);
 		}
+		if (savePath != null) hxd.Save.savePath = savePath;
 		timeoutTick();
 		#if hlsdl
 			sdl.Sdl.init();


### PR DESCRIPTION
* Allows to simplify saving data on PC.
* Ensures that save directory does exist as to not cause exception when saving to `saves/savename` where `saves` does not exist.
* Adds `-D savePath=path/to/save/dir` flag support for hl (except usesys)

Ideally, I'd want to also add binding to automatically use `%appdata%` (and linux/mac alternatives), but that would require implementing [SDL_GetPrefPath](https://wiki.libsdl.org/SDL_GetPrefPath) for hlsdl and also defining of org/app for it to work. For now it at least would allow to specify base path instead of passing path in the save name.
My case: Settings during development, which I want to store in appdata, since build going to be stored in shared folder, hence saving data in cwd would cause a lot of pain with version conflicts and such.