### PR TITLE
fix: handle normalized SDL touch coordinates

### DIFF
--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -255,12 +255,24 @@ class Window {
 			else
 				((c & 0x0F) << 18) | (((e.keyCode >> 8) & 0x7F) << 12) | (((e.keyCode >> 16) & 0x7F) << 6) | ((e.keyCode >> 24) & 0x7F);
 		case TouchDown if (hxd.System.getValue(IsTouch)):
+			#if hlsdl
+				e.mouseX = Std.int(windowWidth * e.mouseX / 100);
+				e.mouseY = Std.int(windowHeight * e.mouseY / 100);
+			#end
 			eh = new Event(EPush, e.mouseX, e.mouseY);
 			eh.touchId = e.fingerId;
 		case TouchMove if (hxd.System.getValue(IsTouch)):
+			#if hlsdl
+				e.mouseX = Std.int(windowWidth * e.mouseX / 100);
+				e.mouseY = Std.int(windowHeight * e.mouseY / 100);
+			#end
 			eh = new Event(EMove, e.mouseX, e.mouseY);
 			eh.touchId = e.fingerId;
 		case TouchUp if (hxd.System.getValue(IsTouch)):
+			#if hlsdl
+				e.mouseX = Std.int(windowWidth * e.mouseX / 100);
+				e.mouseY = Std.int(windowHeight * e.mouseY / 100);
+			#end
 			eh = new Event(ERelease, e.mouseX, e.mouseY);
 			eh.touchId = e.fingerId;
 		#elseif hldx

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -46,6 +46,9 @@ class Window {
 	var curMouseY = 0;
 
 	static var CODEMAP = [for( i in 0...2048 ) i];
+	#if hlsdl
+	static inline var TOUCH_SCALE = #if (hl_ver >= version("1.12.0")) 10000 #else 100 #end;
+	#end
 
 	function new(title:String, width:Int, height:Int, fixed:Bool = false) {
 		this.windowWidth = width;
@@ -256,22 +259,22 @@ class Window {
 				((c & 0x0F) << 18) | (((e.keyCode >> 8) & 0x7F) << 12) | (((e.keyCode >> 16) & 0x7F) << 6) | ((e.keyCode >> 24) & 0x7F);
 		case TouchDown if (hxd.System.getValue(IsTouch)):
 			#if hlsdl
-				e.mouseX = Std.int(windowWidth * e.mouseX / 10000);
-				e.mouseY = Std.int(windowHeight * e.mouseY / 10000);
+				e.mouseX = Std.int(windowWidth * e.mouseX / TOUCH_SCALE);
+				e.mouseY = Std.int(windowHeight * e.mouseY / TOUCH_SCALE);
 			#end
 			eh = new Event(EPush, e.mouseX, e.mouseY);
 			eh.touchId = e.fingerId;
 		case TouchMove if (hxd.System.getValue(IsTouch)):
 			#if hlsdl
-				e.mouseX = Std.int(windowWidth * e.mouseX / 10000);
-				e.mouseY = Std.int(windowHeight * e.mouseY / 10000);
+				e.mouseX = Std.int(windowWidth * e.mouseX / TOUCH_SCALE);
+				e.mouseY = Std.int(windowHeight * e.mouseY / TOUCH_SCALE);
 			#end
 			eh = new Event(EMove, e.mouseX, e.mouseY);
 			eh.touchId = e.fingerId;
 		case TouchUp if (hxd.System.getValue(IsTouch)):
 			#if hlsdl
-				e.mouseX = Std.int(windowWidth * e.mouseX / 10000);
-				e.mouseY = Std.int(windowHeight * e.mouseY / 10000);
+				e.mouseX = Std.int(windowWidth * e.mouseX / TOUCH_SCALE);
+				e.mouseY = Std.int(windowHeight * e.mouseY / TOUCH_SCALE);
 			#end
 			eh = new Event(ERelease, e.mouseX, e.mouseY);
 			eh.touchId = e.fingerId;

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -256,22 +256,22 @@ class Window {
 				((c & 0x0F) << 18) | (((e.keyCode >> 8) & 0x7F) << 12) | (((e.keyCode >> 16) & 0x7F) << 6) | ((e.keyCode >> 24) & 0x7F);
 		case TouchDown if (hxd.System.getValue(IsTouch)):
 			#if hlsdl
-				e.mouseX = Std.int(windowWidth * e.mouseX / 100);
-				e.mouseY = Std.int(windowHeight * e.mouseY / 100);
+				e.mouseX = Std.int(windowWidth * e.mouseX / 10000);
+				e.mouseY = Std.int(windowHeight * e.mouseY / 10000);
 			#end
 			eh = new Event(EPush, e.mouseX, e.mouseY);
 			eh.touchId = e.fingerId;
 		case TouchMove if (hxd.System.getValue(IsTouch)):
 			#if hlsdl
-				e.mouseX = Std.int(windowWidth * e.mouseX / 100);
-				e.mouseY = Std.int(windowHeight * e.mouseY / 100);
+				e.mouseX = Std.int(windowWidth * e.mouseX / 10000);
+				e.mouseY = Std.int(windowHeight * e.mouseY / 10000);
 			#end
 			eh = new Event(EMove, e.mouseX, e.mouseY);
 			eh.touchId = e.fingerId;
 		case TouchUp if (hxd.System.getValue(IsTouch)):
 			#if hlsdl
-				e.mouseX = Std.int(windowWidth * e.mouseX / 100);
-				e.mouseY = Std.int(windowHeight * e.mouseY / 100);
+				e.mouseX = Std.int(windowWidth * e.mouseX / 10000);
+				e.mouseY = Std.int(windowHeight * e.mouseY / 10000);
 			#end
 			eh = new Event(ERelease, e.mouseX, e.mouseY);
 			eh.touchId = e.fingerId;


### PR DESCRIPTION
https://wiki.libsdl.org/SDL_TouchFingerEvent

N.B. : Since we're rounding the normalized value using 100 factor, we can have an 1% windowWidth pixel loss (`792px` vs `799px` for `800px` default windowWidth), maybe we should increase the factor by 10 there and here, what do you think @ncannasse ?

https://github.com/HaxeFoundation/hashlink/blob/a30209ef5020fce4b3b1cda3e7a4fed2edd7f118/libs/sdl/sdl.c#L186-L203