### PR TITLE
[HLSDL] Avoid conflicts between keycodes

### DIFF
--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -45,7 +45,7 @@ class Window {
 	var curMouseX = 0;
 	var curMouseY = 0;
 
-	static var CODEMAP = [for( i in 0...2048 ) i];
+	static var CODEMAP = #if hlsdl []; #else [for( i in 0...2048 ) i]; #end
 	#if hlsdl
 	static inline var TOUCH_SCALE = #if (hl_ver >= version("1.12.0")) 10000 #else 100 #end;
 	#end
@@ -234,6 +234,7 @@ class Window {
 			eh = new Event(EKeyDown);
 			if( e.keyCode & (1 << 30) != 0 ) e.keyCode = (e.keyCode & ((1 << 30) - 1)) + 1000;
 			eh.keyCode = CODEMAP[e.keyCode];
+			if (eh.keyCode == 0) return false;
 			if( eh.keyCode & (K.LOC_LEFT | K.LOC_RIGHT) != 0 ) {
 				e.keyCode = eh.keyCode & 0xFF;
 				onEvent(e);
@@ -242,6 +243,7 @@ class Window {
 			eh = new Event(EKeyUp);
 			if( e.keyCode & (1 << 30) != 0 ) e.keyCode = (e.keyCode & ((1 << 30) - 1)) + 1000;
 			eh.keyCode = CODEMAP[e.keyCode];
+			if (eh.keyCode == 0) return false;
 			if( eh.keyCode & (K.LOC_LEFT | K.LOC_RIGHT) != 0 ) {
 				e.keyCode = eh.keyCode & 0xFF;
 				onEvent(e);
@@ -332,9 +334,14 @@ class Window {
 
 		// EXTRA
 		var keys = [
-			//K.BACKSPACE
-			//K.TAB
-			//K.ENTER
+			8 => K.BACKSPACE,
+			9 => K.TAB,
+			13 => K.ENTER,
+			16 => K.SHIFT,
+			17 => K.CTRL,
+			18 => K.ALT,
+			27 => K.ESCAPE,
+			32 => K.SPACE,
 			1225 => K.LSHIFT,
 			1229 => K.RSHIFT,
 			1224 => K.LCTRL,
@@ -343,8 +350,6 @@ class Window {
 			1230 => K.RALT,
 			1227 => K.LEFT_WINDOW_KEY,
 			1231 => K.RIGHT_WINDOW_KEY,
-			// K.ESCAPE
-			// K.SPACE
 			1075 => K.PGUP,
 			1078 => K.PGDOWN,
 			1077 => K.END,


### PR DESCRIPTION
Currently, sdl keycodes are translated as-is to "windows virtual-key codes", which are not a 1-1 map and cause conflicts (#713, for example).

This PR avoids the automatic mapping of the 2048 first keycodes for hlsdl, and maps manually the missing control keys (backspace, tab, etc.). The actual characters are still available via `e.charCode`.

Fixes #713 