### PR TITLE
Fix Blender exports

### DIFF
--- a/hxd/fmt/fbx/BaseLibrary.hx
+++ b/hxd/fmt/fbx/BaseLibrary.hx
@@ -234,8 +234,6 @@ class BaseLibrary {
 			case "LastSaved|ApplicationName": app = p.props[4].toString();
 			default:
 			}
-		if( app.indexOf("Blender") >= 0 && unitScale == 1 && originScale == 1 )
-			scaleFactor *= 0.01; // Blender in meters exports FBX to centimeter
 
 		if( scaleFactor == 1 && geometryScaleFactor == 1 )
 			return;

--- a/hxd/fmt/fbx/BaseLibrary.hx
+++ b/hxd/fmt/fbx/BaseLibrary.hx
@@ -234,10 +234,8 @@ class BaseLibrary {
 			case "LastSaved|ApplicationName": app = p.props[4].toString();
 			default:
 			}
-		#if fbx_legacy_blender
 		if( app.indexOf("Blender") >= 0 && unitScale == 1 && originScale == 1 )
 			scaleFactor *= 0.01; // Blender in meters exports FBX to centimeter
-		#end
 
 		if( scaleFactor == 1 && geometryScaleFactor == 1 )
 			return;

--- a/hxd/fmt/fbx/BaseLibrary.hx
+++ b/hxd/fmt/fbx/BaseLibrary.hx
@@ -234,8 +234,8 @@ class BaseLibrary {
 			case "LastSaved|ApplicationName": app = p.props[4].toString();
 			default:
 			}
-		if( app.indexOf("Blender") >= 0 && unitScale == 1 && originScale == 1 )
-			scaleFactor *= 0.01; // Blender in meters exports FBX to centimeter
+		if( app.indexOf("Blender") >= 0 && unitScale == originScale )
+			scaleFactor = unitScale / 100; // Adjust blender output scaling
 
 		if( scaleFactor == 1 && geometryScaleFactor == 1 )
 			return;

--- a/hxd/fmt/fbx/BaseLibrary.hx
+++ b/hxd/fmt/fbx/BaseLibrary.hx
@@ -234,6 +234,10 @@ class BaseLibrary {
 			case "LastSaved|ApplicationName": app = p.props[4].toString();
 			default:
 			}
+		#if fbx_legacy_blender
+		if( app.indexOf("Blender") >= 0 && unitScale == 1 && originScale == 1 )
+			scaleFactor *= 0.01; // Blender in meters exports FBX to centimeter
+		#end
 
 		if( scaleFactor == 1 && geometryScaleFactor == 1 )
 			return;

--- a/hxd/fmt/fbx/Parser.hx
+++ b/hxd/fmt/fbx/Parser.hx
@@ -183,16 +183,14 @@ class Parser {
 	}
 	
 	static final ZERO_BYTE = String.fromCharCode(0);
-	function readBinaryString(length : Int) : String {
-		if (length == 0) return "";
+	function readBinaryString( length : Int ) : String {
+		if  (length == 0 ) return "";
 		var str = bytes.getString(pos, length);
 		pos += length;
 		// Blender inserts extra data to strings following `\0\1` byte sequence
 		// expecting them to be stripped away due to 0 byte being terminator.
 		var zeroPos = str.indexOf(ZERO_BYTE);
-		if (zeroPos != -1) {
-			str = str.substr(0, zeroPos);
-		}
+		if ( zeroPos != -1 ) str = str.substr(0, zeroPos);
 		return str;
 	}
 	

--- a/hxd/fmt/fbx/Parser.hx
+++ b/hxd/fmt/fbx/Parser.hx
@@ -182,15 +182,18 @@ class Parser {
 		}
 	}
 	
-	static final ZERO_BYTE = String.fromCharCode(0);
 	function readBinaryString( length : Int ) : String {
 		if  (length == 0 ) return "";
 		var str = bytes.getString(pos, length);
 		pos += length;
 		// Blender inserts extra data to strings following `\0\1` byte sequence
 		// expecting them to be stripped away due to 0 byte being terminator.
-		var zeroPos = str.indexOf(ZERO_BYTE);
-		if ( zeroPos != -1 ) str = str.substr(0, zeroPos);
+		final len = str.length;
+		for ( i in 0...len ) {
+			if ( str.charCodeAt(i) == 0 ) {
+				return str.substr(0, i);
+			}
+		}
 		return str;
 	}
 	


### PR DESCRIPTION
* Altered string parsing on binary FBX. Now it cuts off anything past `0` byte if it's present in a string. This is due to Blender inserting `\0\1AnimCurveNode` extra data to curve node names, clearly expecting it being cut away on parsing.
* Removed Blender downscale hack: It's no longer required, as it's possible to export with proper unit scale (see wiki notes).