### PR TITLE
Fix FileTree completion in macro context

### DIFF
--- a/hxd/res/FileTree.hx
+++ b/hxd/res/FileTree.hx
@@ -1,4 +1,5 @@
 package hxd.res;
+#if macro
 import haxe.macro.Context;
 import haxe.macro.Expr;
 
@@ -375,3 +376,4 @@ class FileTree {
 	}
 
 }
+#end


### PR DESCRIPTION
Gate out `hxd.res.FileTree` in `macro` in order to fix haxe completion (e.g. explicitly showcase that this is macro context)