### PR TITLE
Fix javascript error in GlDriver

### DIFF
--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -188,7 +188,7 @@ class GlDriver extends Driver {
 			gl = cast canvas.getContextWebGL(options);
 		if( gl == null ) throw "Could not acquire GL context";
 		// debug if webgl_debug.js is included
-		if( js.Syntax.code('typeof {0}', untyped WebGLDebugUtils) != "undefined" ) {
+		if( js.Syntax.typeof(untyped WebGLDebugUtils) != "undefined" ) {
 			gl = untyped WebGLDebugUtils.makeDebugContext(gl);
 			glDebug = true;
 		}

--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -188,7 +188,7 @@ class GlDriver extends Driver {
 			gl = cast canvas.getContextWebGL(options);
 		if( gl == null ) throw "Could not acquire GL context";
 		// debug if webgl_debug.js is included
-		if( js.Syntax.code('typeof')(untyped WebGLDebugUtils) != "undefined" ) {
+		if( js.Syntax.code('typeof {0}', untyped WebGLDebugUtils) != "undefined" ) {
 			gl = untyped WebGLDebugUtils.makeDebugContext(gl);
 			glDebug = true;
 		}


### PR DESCRIPTION
The original code generated `if((typeof)(WebGLDebugUtils) != "undefined")` which doesn't run in a browser. This should generate `if((typeof WebGLDebugUtils) != "undefined")` which will.

I'm a haxe novice and am not sure if this is the correct fix, but it appears to work.