### PR TITLE
Fix name collision in Pak FS

### DIFF
--- a/hxd/fmt/pak/FileSystem.hx
+++ b/hxd/fmt/pak/FileSystem.hx
@@ -5,20 +5,21 @@ import hxd.impl.Air3File;
 #elseif (sys || nodejs)
 import sys.io.File;
 import sys.io.FileInput;
+import sys.io.FileSeek as SeekType;
 #else
-enum FileSeek {
+enum SeekType {
 	SeekBegin;
 	SeekEnd;
-	SeedCurrent;
+	SeekCurrent;
 }
 class FileInput extends haxe.io.BytesInput {
-	public function seek( pos : Int, seekMode : FileSeek ) {
+	public function seek( pos : Int, seekMode : SeekType ) {
 		switch( seekMode ) {
 		case SeekBegin:
 			this.position = pos;
 		case SeekEnd:
 			this.position = this.length - pos;
-		case SeedCurrent:
+		case SeekCurrent:
 			this.position += pos;
 		}
 	}
@@ -30,7 +31,7 @@ class FileSeek {
 	@:hlNative("std","file_seek2") static function seek2( f : sys.io.File.FileHandle, pos : Float, cur : Int ) : Bool { return false; }
 	#end
 	
-	public static function seek( f : sys.io.FileInput, pos : Float, mode : sys.io.FileSeek ) {
+	public static function seek( f : FileInput, pos : Float, mode : SeekType ) {
 		#if (hl && hl_ver >= version("1.12.0"))
 		if( !seek2(@:privateAccess f.__f,pos,mode.getIndex()) )
 			throw haxe.io.Error.Custom("seek2 failure()");

--- a/hxd/impl/Air3File.hx
+++ b/hxd/impl/Air3File.hx
@@ -1,6 +1,6 @@
 package hxd.impl;
 
-enum FileSeek {
+enum SeekType {
 	SeekBegin;
 	SeekCur;
 	SeekEnd;
@@ -29,7 +29,7 @@ class FileInput extends haxe.io.Input {
 		}
 	}
 
-	public function seek( p : Int, pos : FileSeek ) {
+	public function seek( p : Int, pos : SeekType ) {
 		switch( pos ) {
 		case SeekBegin:
 			if( p < 0 ) p = 0;


### PR DESCRIPTION
Fixes name collision introduced by https://github.com/HeapsIO/heaps/commit/37414f0189b317b08d982b2dfc00072a4eafa190 on non-system targets.
This way, it should no longer break the travis status as well as fixes usage of pak files on HTML5.