### PR TITLE
fixed compilation warning related to deprecation

### DIFF
--- a/hxd/res/Embed.hx
+++ b/hxd/res/Embed.hx
@@ -104,7 +104,7 @@ class Embed {
 
 	#if js
 	static function __init__() untyped {
-		__js__("var hx__registerFont");
+		js.Syntax.code("var hx__registerFont");
 		untyped hx__registerFont = function(name, data) {
 			var s = js.Browser.document.createStyleElement();
 			s.type = "text/css";


### PR DESCRIPTION
used to get this:
```
-> % haxe hxml/js.hxml
~/haxelib/heaps/git/hxd/res/Embed.hx:107: characters 3-9 : Warning : __js__ is deprecated, use js.Syntax.code instead
```

now seems to be fixed