### PR TITLE
Fix TIFF compilation on JS

### DIFF
--- a/hxd/fmt/pak/FileSystem.hx
+++ b/hxd/fmt/pak/FileSystem.hx
@@ -23,6 +23,10 @@ class FileInput extends haxe.io.BytesInput {
 			this.position += pos;
 		}
 	}
+
+	public function tell() {
+		return this.position;
+	}
 }
 #end
 

--- a/hxd/fmt/tiff/Reader.hx
+++ b/hxd/fmt/tiff/Reader.hx
@@ -1,11 +1,18 @@
 package hxd.fmt.tiff;
+
 import hxd.fmt.tiff.Data;
+#if sys
+import sys.io.FileInput;
+#else
+import hxd.fmt.pak.FileSystem.FileInput;
+#end
+
 
 class Reader {
 
-	var f : sys.io.FileInput;
+	var f : FileInput;
 
-	public function new(f:sys.io.FileInput) {
+	public function new(f:FileInput) {
 		this.f = f;
 	}
 


### PR DESCRIPTION
Couldn't generate API docs because TIFF refused to compile on JS, since not a sys target.

* Added `tell` method to `hxd.fmt.pak.FileSystem.FileInput`
* Added conditional import of either sys FileInput or pak FileInput depending on target.

This is probably not the best solution, but at least works as a substitute to not break the JS. Honestly, there needs to be a better way to make cross-platform seekable input...

Pls don't break JS ;)