### PR TITLE
Fix #875

### DIFF
--- a/h2d/impl/BatchDrawState.hx
+++ b/h2d/impl/BatchDrawState.hx
@@ -53,7 +53,8 @@ class BatchDrawState {
 			if ( tail.texture == null ) tail.texture = texture;
 			else if ( tail.texture != texture ) {
 				var cur = tail;
-				if ( cur.next == null ) cur.next = tail = new StateEntry(texture);
+				if ( cur.count == 0 ) cur.set(texture);
+				else if ( cur.next == null ) cur.next = tail = new StateEntry(texture);
 				else tail = cur.next.set(texture);
 			}
 		}


### PR DESCRIPTION
* Fixes #875 as mentioned by introducing separate white tile when doing line or solid color fills. 
* Fixed an oversight with previous drawbatchstate implementation where passing null tile to `beginTileFill` was not allowed, yet in original version it would use current `Graphics.tile` value.
* Also fixed an oversight in state switch logic: Not changing between textures but not adding any geometry should not produce new state instances. 