### PR TITLE
Implement @doc meta for shaders

### DIFF
--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -83,6 +83,7 @@ enum VarQualifier {
 	Range( min : Float, max : Float );
 	Ignore; // the variable is ignored in reflection (inspector)
 	PerInstance( v : Int );
+	Doc( s : String );
 }
 
 enum Prec {
@@ -97,7 +98,6 @@ typedef VarDecl = {
 	var kind : Null<VarKind>;
 	var qualifiers : Array<VarQualifier>;
 	var expr : Null<Expr>;
-	var doc : Null<String>;
 }
 
 typedef FunDecl = {
@@ -146,7 +146,6 @@ typedef TVar = {
 	var kind : VarKind;
 	@:optional var parent : TVar;
 	@:optional var qualifiers : Null<Array<VarQualifier>>;
-	@:optional var doc : Null<String>;
 }
 
 typedef TFunction = {
@@ -315,6 +314,17 @@ class Tools {
 			default:
 			}
 		return v.name;
+	}
+
+	public static function getDoc( v : TVar ) {
+		if ( v.qualifiers == null )
+			return null;
+		for ( q in v.qualifiers )
+			switch ( q ) {
+			case Doc(s): return s;
+			default:
+			}
+		return null;
 	}
 
 	public static function getConstBits( v : TVar ) {

--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -97,6 +97,7 @@ typedef VarDecl = {
 	var kind : Null<VarKind>;
 	var qualifiers : Array<VarQualifier>;
 	var expr : Null<Expr>;
+	var doc : Null<String>;
 }
 
 typedef FunDecl = {
@@ -145,6 +146,7 @@ typedef TVar = {
 	var kind : VarKind;
 	@:optional var parent : TVar;
 	@:optional var qualifiers : Null<Array<VarQualifier>>;
+	@:optional var doc : Null<String>;
 }
 
 typedef TFunction = {

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -236,6 +236,7 @@ class Checker {
 				name : f.name,
 				kind : Function,
 				type : TFun([{ args : [for( a in args ) { type : a.type, name : a.name }], ret : f.ret == null ? TVoid : f.ret }]),
+				doc: null,
 			};
 			var f : TFunction = {
 				kind : kind,
@@ -745,6 +746,7 @@ class Checker {
 			name : v.name,
 			kind : v.kind,
 			type : v.type,
+			doc: v.doc,
 		};
 		if( parent != null )
 			tv.parent = parent;
@@ -810,7 +812,7 @@ class Checker {
 			parent.type = TStruct(vl);
 			for( i in 0...vl.length ) {
 				var v = vl[i];
-				vl[i] = makeVar( { type : v.type, qualifiers : v.qualifiers, name : v.name, kind : v.kind, expr : null }, pos, parent);
+				vl[i] = makeVar( { type : v.type, qualifiers : v.qualifiers, name : v.name, kind : v.kind, expr : null, doc: v.doc }, pos, parent);
 			}
 			return parent.type;
 		case TArray(t, size), TBuffer(t,size):

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -235,7 +235,7 @@ class Checker {
 				id : Tools.allocVarId(),
 				name : f.name,
 				kind : Function,
-				type : TFun([{ args : [for( a in args ) { type : a.type, name : a.name }], ret : f.ret == null ? TVoid : f.ret }])
+				type : TFun([{ args : [for( a in args ) { type : a.type, name : a.name }], ret : f.ret == null ? TVoid : f.ret }]),
 			};
 			var f : TFunction = {
 				kind : kind,
@@ -744,7 +744,7 @@ class Checker {
 			id : Tools.allocVarId(),
 			name : v.name,
 			kind : v.kind,
-			type : v.type
+			type : v.type,
 		};
 		if( parent != null )
 			tv.parent = parent;

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -235,8 +235,7 @@ class Checker {
 				id : Tools.allocVarId(),
 				name : f.name,
 				kind : Function,
-				type : TFun([{ args : [for( a in args ) { type : a.type, name : a.name }], ret : f.ret == null ? TVoid : f.ret }]),
-				doc: null,
+				type : TFun([{ args : [for( a in args ) { type : a.type, name : a.name }], ret : f.ret == null ? TVoid : f.ret }])
 			};
 			var f : TFunction = {
 				kind : kind,
@@ -745,8 +744,7 @@ class Checker {
 			id : Tools.allocVarId(),
 			name : v.name,
 			kind : v.kind,
-			type : v.type,
-			doc: v.doc,
+			type : v.type
 		};
 		if( parent != null )
 			tv.parent = parent;
@@ -796,7 +794,7 @@ class Checker {
 					default:
 						error("Precision qualifier not supported on " + v.type, pos);
 					}
-				case Ignore:
+				case Ignore, Doc(_):
 				}
 		}
 		if( tv.type != null )
@@ -812,7 +810,7 @@ class Checker {
 			parent.type = TStruct(vl);
 			for( i in 0...vl.length ) {
 				var v = vl[i];
-				vl[i] = makeVar( { type : v.type, qualifiers : v.qualifiers, name : v.name, kind : v.kind, expr : null, doc: v.doc }, pos, parent);
+				vl[i] = makeVar( { type : v.type, qualifiers : v.qualifiers, name : v.name, kind : v.kind, expr : null }, pos, parent);
 			}
 			return parent.type;
 		case TArray(t, size), TBuffer(t,size):

--- a/hxsl/MacroParser.hx
+++ b/hxsl/MacroParser.hx
@@ -26,6 +26,9 @@ class MacroParser {
 		case [ { expr : EConst(CInt(a)) } ] if( m.name == "perInstance" ):
 			v.qualifiers.push(PerInstance(Std.parseInt(a)));
 			return;
+		case [ { expr: EConst(CString(c)), pos: pos } ] if (m.name == "doc"):
+			v.doc = c;
+			return;
 		default:
 			error("Invalid meta parameter for "+m.name, m.pos);
 		}
@@ -121,6 +124,7 @@ class MacroParser {
 						qualifiers : [],
 						kind : null,
 						expr : null,
+						doc: null
 					};
 					for( m in f.meta )
 						applyMeta(m,v);
@@ -164,6 +168,7 @@ class MacroParser {
 					type : v.type == null ? null : parseType(v.type, e.pos),
 					kind : null,
 					qualifiers : [],
+					doc : null,
 				}
 			}]);
 		#if haxe4
@@ -184,6 +189,7 @@ class MacroParser {
 						kind : Local,
 						qualifiers : [],
 						expr : a.value == null ? (a.opt ? { expr : EConst(CNull), pos : e.pos } : null) : parseExpr(a.value),
+						doc: null,
 					}
 				}],
 				expr : parseExpr(f.expr),

--- a/hxsl/MacroParser.hx
+++ b/hxsl/MacroParser.hx
@@ -123,7 +123,7 @@ class MacroParser {
 						type : t == null ? null : parseType(t, f.pos),
 						qualifiers : [],
 						kind : null,
-						expr : null
+						expr : null,
 					};
 					for( m in f.meta )
 						applyMeta(m,v);
@@ -166,7 +166,7 @@ class MacroParser {
 					expr : v.expr == null ? null : parseExpr(v.expr),
 					type : v.type == null ? null : parseType(v.type, e.pos),
 					kind : null,
-					qualifiers : []
+					qualifiers : [],
 				}
 			}]);
 		#if haxe4
@@ -186,7 +186,7 @@ class MacroParser {
 						type : a.type == null ? null : parseType(a.type, e.pos),
 						kind : Local,
 						qualifiers : [],
-						expr : a.value == null ? (a.opt ? { expr : EConst(CNull), pos : e.pos } : null) : parseExpr(a.value)
+						expr : a.value == null ? (a.opt ? { expr : EConst(CNull), pos : e.pos } : null) : parseExpr(a.value),
 					}
 				}],
 				expr : parseExpr(f.expr),

--- a/hxsl/MacroParser.hx
+++ b/hxsl/MacroParser.hx
@@ -26,8 +26,8 @@ class MacroParser {
 		case [ { expr : EConst(CInt(a)) } ] if( m.name == "perInstance" ):
 			v.qualifiers.push(PerInstance(Std.parseInt(a)));
 			return;
-		case [ { expr: EConst(CString(c)), pos: pos } ] if (m.name == "doc"):
-			v.doc = c;
+		case [ { expr: EConst(CString(s)), pos: pos } ] if (m.name == "doc"):
+			v.qualifiers.push(Doc(s));
 			return;
 		default:
 			error("Invalid meta parameter for "+m.name, m.pos);
@@ -123,8 +123,7 @@ class MacroParser {
 						type : t == null ? null : parseType(t, f.pos),
 						qualifiers : [],
 						kind : null,
-						expr : null,
-						doc: null
+						expr : null
 					};
 					for( m in f.meta )
 						applyMeta(m,v);
@@ -167,8 +166,7 @@ class MacroParser {
 					expr : v.expr == null ? null : parseExpr(v.expr),
 					type : v.type == null ? null : parseType(v.type, e.pos),
 					kind : null,
-					qualifiers : [],
-					doc : null,
+					qualifiers : []
 				}
 			}]);
 		#if haxe4
@@ -188,8 +186,7 @@ class MacroParser {
 						type : a.type == null ? null : parseType(a.type, e.pos),
 						kind : Local,
 						qualifiers : [],
-						expr : a.value == null ? (a.opt ? { expr : EConst(CNull), pos : e.pos } : null) : parseExpr(a.value),
-						doc: null,
+						expr : a.value == null ? (a.opt ? { expr : EConst(CNull), pos : e.pos } : null) : parseExpr(a.value)
 					}
 				}],
 				expr : parseExpr(f.expr),

--- a/hxsl/Macros.hx
+++ b/hxsl/Macros.hx
@@ -151,6 +151,7 @@ class Macros {
 					pos : pos,
 					kind : FProp("get","set", t),
 					access : [APublic],
+					doc: v.doc,
 				};
 				var name = v.name + "__";
 				var initVal = null;

--- a/hxsl/Macros.hx
+++ b/hxsl/Macros.hx
@@ -4,7 +4,7 @@ import haxe.macro.Expr;
 using hxsl.Ast;
 
 class Macros {
-
+	#if macro
 	static function makeType( t : Type ) : ComplexType {
 		return switch( t ) {
 		case TVoid: macro : Void;
@@ -151,7 +151,7 @@ class Macros {
 					pos : pos,
 					kind : FProp("get","set", t),
 					access : [APublic],
-					doc: v.doc,
+					doc: v.getDoc(),
 				};
 				var name = v.name + "__";
 				var initVal = null;
@@ -478,5 +478,5 @@ class Macros {
 		});
 		return fields;
 	}
-
+	#end
 }

--- a/hxsl/Printer.hx
+++ b/hxsl/Printer.hx
@@ -48,8 +48,6 @@ class Printer {
 	}
 
 	function addVar( v : TVar, defKind : VarKind, tabs = "", ?parent ) {
-		if (v.doc != null)
-			add("@doc(" + StringTools.replace(v.doc, '"', '\\"') + ") ");
 		if( v.qualifiers != null ) {
 			for( q in v.qualifiers )
 				add("@" + (switch( q ) {
@@ -63,6 +61,7 @@ class Printer {
 				case Range(min, max): "range(" + min + "," + max + ")";
 				case Ignore: "ignore";
 				case PerInstance(n): "perInstance("+n+")";
+				case Doc(s): "doc(\"" + StringTools.replace(s, '"', '\\"') + "\")";
 				}) + " ");
 		}
 		if( v.kind != defKind )

--- a/hxsl/Printer.hx
+++ b/hxsl/Printer.hx
@@ -48,6 +48,8 @@ class Printer {
 	}
 
 	function addVar( v : TVar, defKind : VarKind, tabs = "", ?parent ) {
+		if (v.doc != null)
+			add("@doc(" + StringTools.replace(v.doc, '"', '\\"') + ") ");
 		if( v.qualifiers != null ) {
 			for( q in v.qualifiers )
 				add("@" + (switch( q ) {

--- a/hxsl/Serializer.hx
+++ b/hxsl/Serializer.hx
@@ -184,6 +184,7 @@ class Serializer {
 				case Precision(p): out.addByte(p.getIndex());
 				case Range(min, max): out.addDouble(min); out.addDouble(max);
 				case PerInstance(v): out.addInt32(v);
+				case Doc(s): writeString(s);
 				}
 			}
 		}
@@ -397,6 +398,7 @@ class Serializer {
 				case 7: Range(input.readDouble(), input.readDouble());
 				case 8: Ignore;
 				case 9: PerInstance(input.readInt32());
+				case 10: Doc(readString());
 				default: throw "assert";
 				}
 				v.qualifiers.push(q);


### PR DESCRIPTION
Adds support for `@doc` metadata in HXSL shaders. 
Primary aim is to enable documentation of the variables generated by macros.
Usage example (from Base2d):
```haxe
		@doc("Discard pixels with alpha below 0.001")
		@const var killAlpha : Bool;
```