### PR TITLE
Fix FloatBuffer behavior on JS when using arrayAccess path

### DIFF
--- a/hxd/FloatBuffer.hx
+++ b/hxd/FloatBuffer.hx
@@ -12,7 +12,7 @@ private abstract Float32Expand({ pos : Int, array : hxd.impl.TypedArray.Float32A
 		this = { pos : length, array : new Float32Array(new ArrayBuffer(length<<2)) };
 	}
 
-	inline function get_length() return this.array.length;
+	inline function get_length() return this.pos;
 	inline function set_length(v:Int) {
 		if( length != v ) {
 			var newArray = new Float32Array(v);

--- a/hxd/FloatBuffer.hx
+++ b/hxd/FloatBuffer.hx
@@ -12,7 +12,7 @@ private abstract Float32Expand({ pos : Int, array : hxd.impl.TypedArray.Float32A
 		this = { pos : length, array : new Float32Array(new ArrayBuffer(length<<2)) };
 	}
 
-	inline function get_length() return this.pos;
+	inline function get_length() return this.array.length;
 	inline function set_length(v:Int) {
 		if( length != v ) {
 			var newArray = new Float32Array(v);

--- a/hxd/FloatBuffer.hx
+++ b/hxd/FloatBuffer.hx
@@ -25,17 +25,27 @@ private abstract Float32Expand({ pos : Int, array : hxd.impl.TypedArray.Float32A
 
 	public inline function push(v:Float) {
 		if( this.pos == this.array.length ) {
-			var newSize = this.array.length << 1;
-			if( newSize < 128 ) newSize = 128;
-			var newArray = new Float32Array(newSize);
-			newArray.set(this.array);
-			this.array = newArray;
+			expand(this.array.length);
 		}
 		this.array[this.pos++] = v;
 	}
 
+	inline function expand(length: Int) {
+		var newSize = length << 1;
+		if( newSize < 128 ) newSize = 128;
+		var newArray = new Float32Array(newSize);
+		newArray.set(this.array);
+		this.array = newArray;
+	}
+
 	@:arrayAccess inline function get(index) return this.array[index];
-	@:arrayAccess inline function set(index,v:Float) return this.array[index] = v;
+	@:arrayAccess inline function set(index,v:Float) {
+		if( this.pos <= index ) {
+			expand( index );
+			this.pos = index + 1;
+		}
+		return this.array[index] = v;
+	}
 
 	@:to inline function toF32Array() return this.array;
 	@:to inline function toArray() return [for( i in 0...this.pos ) this.array[i]];


### PR DESCRIPTION
FloatBuffer on JS does not expand when using array access, which causes all kinds of exciting behavioral issues. This PR moves the expansion logic into a function that's called on both push and array access paths.