### PR TITLE
Fix Std.is deprecation warnings

### DIFF
--- a/h2d/HtmlText.hx
+++ b/h2d/HtmlText.hx
@@ -801,7 +801,7 @@ class HtmlText extends Text {
 	override function getBoundsRec( relativeTo : Object, out : h2d.col.Bounds, forSize : Bool ) {
 		if( forSize )
 			for( i in elements )
-				if( Std.is(i,h2d.Bitmap) )
+				if( hxd.impl.Api.is(i,h2d.Bitmap) )
 					i.visible = false;
 		super.getBoundsRec(relativeTo, out, forSize);
 		if( forSize )

--- a/h2d/domkit/Style.hx
+++ b/h2d/domkit/Style.hx
@@ -360,7 +360,7 @@ class Style extends domkit.CssStyle {
 		var dom = obj.dom;
 		if(dom != null) {
 			for( s in dom.style ) {
-				if( s.p.name == "text" || Std.is(s.value,h2d.Tile) ) continue;
+				if( s.p.name == "text" || hxd.impl.Api.is(s.value,h2d.Tile) ) continue;
 				lines.push(' <font color="#D0D0D0"> ${s.p.name}</font> <font color="#808080">${s.value}</font><font color="#606060"> (style)</font>');
 			}
 			for( i in 0...dom.currentSet.length ) {

--- a/h2d/filter/AbstractMask.hx
+++ b/h2d/filter/AbstractMask.hx
@@ -82,7 +82,7 @@ class AbstractMask extends Filter {
 		mask = m;
 		if( m != null && bindCount > 0 ) {
 			if( m.filter != null ) {
-				if( Std.is(m.filter,Hide) ) throw "Same mask can't be part of several filters";
+				if( hxd.impl.Api.is(m.filter,Hide) ) throw "Same mask can't be part of several filters";
 				throw "Can't set mask with filter "+m.filter;
 			}
 			m.filter = hide;

--- a/h3d/scene/Renderer.hx
+++ b/h3d/scene/Renderer.hx
@@ -61,7 +61,7 @@ class Renderer extends hxd.impl.AnyProps {
 
 	public function getPass<T:h3d.pass.Base>( c : Class<T> ) : T {
 		for( p in allPasses )
-			if( Std.is(p, c) )
+			if( hxd.impl.Api.is(p, c) )
 				return cast p;
 		return null;
 	}

--- a/hxd/fs/FileConverter.hx
+++ b/hxd/fs/FileConverter.hx
@@ -118,7 +118,7 @@ class FileConverter {
 	}
 
 	function makeCommmand( obj : Dynamic ) : { cmd : ConvertCommand, priority : Int } {
-		if( Std.is(obj,String) )
+		if( hxd.impl.Api.is(obj,String) )
 			return { cmd : { conv : loadConvert(obj) }, priority : 0 };
 		if( obj.convert == null )
 			throw "Missing 'convert' in "+obj;
@@ -132,7 +132,7 @@ class FileConverter {
 			case "priority": priority = value;
 			default:
 				if( cmd.params == null ) cmd.params = {};
-				if( Reflect.isObject(value) && !Std.is(value,String) ) throw "Invalid parameter value "+f+"="+value;
+				if( Reflect.isObject(value) && !hxd.impl.Api.is(value,String) ) throw "Invalid parameter value "+f+"="+value;
 				Reflect.setField(cmd.params, f, value);
 			}
 		}

--- a/hxd/impl/Api.hx
+++ b/hxd/impl/Api.hx
@@ -10,4 +10,12 @@ class Api {
 		#end
 	}
 
+	public static inline function is( v : Dynamic, t : Dynamic) : Bool {
+		#if (haxe_ver >= 4.1)
+		return Std.isOfType(v, t);
+		#else
+		return Std.is(v, t);
+		#end
+	}
+
 }

--- a/hxd/inspect/PropManager.hx
+++ b/hxd/inspect/PropManager.hx
@@ -194,7 +194,7 @@ class PropManager extends vdom.Client {
 
 	public function sameValue( v1 : Dynamic, v2 : Dynamic ) {
 		if( v1 == v2 ) return true;
-		if( Std.is(v1, Array) && Std.is(v2, Array) ) {
+		if( hxd.impl.Api.is(v1, Array) && hxd.impl.Api.is(v2, Array) ) {
 			var a1 : Array<Dynamic> = v1;
 			var a2 : Array<Dynamic> = v2;
 			if( a1.length != a2.length )

--- a/hxd/inspect/PropTools.hx
+++ b/hxd/inspect/PropTools.hx
@@ -1,11 +1,12 @@
 package hxd.inspect;
+import hxd.impl.Api;
 
 class PropTools {
 
 	public static function setPropValue( p : Property, v : Dynamic, lerp = 1. ) {
 		switch( p ) {
 		case PInt(_, get, set):
-			if( !Std.is(v, Int) ) throw "Invalid int value " + v;
+			if( !Api.is(v, Int) ) throw "Invalid int value " + v;
 			var v : Int = v;
 			if( lerp == 1 )
 				set(v);
@@ -15,29 +16,29 @@ class PropTools {
 				set( prev < v ? Math.ceil(u) : Math.floor(u) );
 			}
 		case PFloat(_, get, set):
-			if( !Std.is(v, Float) ) throw "Invalid float value " + v;
+			if( !Api.is(v, Float) ) throw "Invalid float value " + v;
 			if( lerp == 1 )
 				set(v);
 			else
 				set(hxd.Math.lerp(get(), v, lerp));
 		case PRange(_, _, _, get, set):
-			if( !Std.is(v, Float) ) throw "Invalid float value " + v;
+			if( !Api.is(v, Float) ) throw "Invalid float value " + v;
 			if( lerp == 1 )
 				set(v);
 			else
 				set(hxd.Math.lerp(get(), v, lerp));
 		case PBool(_, _, set):
-			if( !Std.is(v, Bool) ) throw "Invalid bool value " + v;
+			if( !Api.is(v, Bool) ) throw "Invalid bool value " + v;
 			set(v);
 		case PString(_, _, set):
-			if( v != null && !Std.is(v, String) ) throw "Invalid string value " + v;
+			if( v != null && !Api.is(v, String) ) throw "Invalid string value " + v;
 			set(v);
 		case PEnum(_, en, _, set):
 			var e = en.createAll()[v];
-			if( e == null || !Std.is(v, Int) ) throw "Invalid enum " + en.getName() + " value " + v;
+			if( e == null || !Api.is(v, Int) ) throw "Invalid enum " + en.getName() + " value " + v;
 			set(e);
 		case PColor(_, _, get, set):
-			if( !Std.is(v, String) ) throw "Invalid color value " + v;
+			if( !Api.is(v, String) ) throw "Invalid color value " + v;
 			var v : String = v;
 			var newV = h3d.Vector.fromColor(Std.parseInt("0x" + v.substr(1)));
 			if( lerp == 1 )
@@ -51,7 +52,7 @@ class PropTools {
 				set(newV);
 			}
 		case PFloats(_, get, set):
-			if( !Std.is(v, Array) ) throw "Invalid floats value " + v;
+			if( !Api.is(v, Array) ) throw "Invalid floats value " + v;
 			var a : Array<Float> = v;
 			var prev = get();
 			var need = prev.length;
@@ -65,7 +66,7 @@ class PropTools {
 				set(newA);
 			}
 		case PTexture(_, _, set):
-			if( !Std.is(v, String) ) throw "Invalid texture value " + v;
+			if( !Api.is(v, String) ) throw "Invalid texture value " + v;
 			var path : String = v;
 			if( path.charCodeAt(0) != '/'.code && path.charCodeAt(1) != ':'.code ) {
 				set(hxd.res.Loader.currentInstance.load(path).toTexture());

--- a/hxd/inspect/ScenePanel.hx
+++ b/hxd/inspect/ScenePanel.hx
@@ -1,5 +1,6 @@
 package hxd.inspect;
 import hxd.inspect.Property;
+import hxd.impl.Api;
 
 private class SceneObject extends TreeNode {
 
@@ -333,17 +334,17 @@ class ScenePanel extends Panel {
 	}
 
 	function getObjectIcon( o : h3d.scene.Object) {
-		if( Std.is(o, h3d.scene.Skin) )
+		if( Api.is(o, h3d.scene.Skin) )
 			return "child";
-		if( Std.is(o, h3d.parts.Particles) || Std.is(o,h3d.parts.GpuParticles) )
+		if( Api.is(o, h3d.parts.Particles) || Api.is(o,h3d.parts.GpuParticles) )
 			return "sun-o";
-		if( Std.is(o, h3d.scene.Mesh) )
+		if( Api.is(o, h3d.scene.Mesh) )
 			return "cube";
-		if( Std.is(o, h3d.scene.CustomObject) )
+		if( Api.is(o, h3d.scene.CustomObject) )
 			return "globe";
-		if( Std.is(o, h3d.scene.Scene) )
+		if( Api.is(o, h3d.scene.Scene) )
 			return "picture-o";
-		if( Std.is(o, h3d.scene.Light) )
+		if( Api.is(o, h3d.scene.Light) )
 			return "lightbulb-o";
 		return null;
 	}

--- a/hxd/inspect/SceneProps.hx
+++ b/hxd/inspect/SceneProps.hx
@@ -1,5 +1,6 @@
 package hxd.inspect;
 import hxd.inspect.Property;
+import hxd.impl.Api;
 
 enum RendererSection {
 	Core;
@@ -46,7 +47,7 @@ class SceneProps {
 			var m = Reflect.field(meta, f);
 			if( m != null && Reflect.hasField(m, "ignore") ) continue;
 			var v = Reflect.field(r, f);
-			if( !Std.is(v, hxsl.Shader) && !Std.is(v, h3d.pass.ScreenFx) && !Std.is(v,Group) ) continue;
+			if( !Api.is(v, hxsl.Shader) && !Api.is(v, h3d.pass.ScreenFx) && !Api.is(v,Group) ) continue;
 
 			if( prev != null && StringTools.startsWith(f, prev.name) ) {
 				prev.group.push({ name : f.substr(prev.name.length), v : v });
@@ -120,7 +121,7 @@ class SceneProps {
 		case Core:
 
 			var props = [];
-			addDynamicProps(props, r, function(v) return !Std.is(v,hxsl.Shader) && !Std.is(v,h3d.pass.ScreenFx) && !Std.is(v,Group));
+			addDynamicProps(props, r, function(v) return !Api.is(v,hxsl.Shader) && !Api.is(v,h3d.pass.ScreenFx) && !Api.is(v,Group));
 			return props;
 
 		}
@@ -287,7 +288,7 @@ class SceneProps {
 	}
 
 	function getDynamicProps( v : Dynamic ) : Array<Property> {
-		if( Std.is(v,h3d.pass.ScreenFx) || Std.is(v,Group) ) {
+		if( Api.is(v,h3d.pass.ScreenFx) || Api.is(v,Group) ) {
 			var props = [];
 			addDynamicProps(props, v);
 			return props;
@@ -342,9 +343,9 @@ class SceneProps {
 				continue;
 
 			if( m != null && Reflect.hasField(m, "inspect") ) {
-				if( Std.is(v, Bool) )
+				if( Api.is(v, Bool) )
 					props.unshift(PBool(f, function() return Reflect.getProperty(o, f), function(v) Reflect.setProperty(o, f, v)));
-				else if( Std.is(v, Float) ) {
+				else if( Api.is(v, Float) ) {
 					var range : Array<Dynamic> = m.range;
 					if( range != null )
 						props.unshift(PRange(f, range[0], range[1], function() return Reflect.getProperty(o, f), function(v) Reflect.setProperty(o, f, v), range[2]));
@@ -401,7 +402,7 @@ class SceneProps {
 		var props = null;
 		for( f in Reflect.fields(propsValues) ) {
 			var v : Dynamic = Reflect.field(propsValues, f);
-			var isObj = Reflect.isObject(v) && !Std.is(v, String) && !Std.is(v, Array);
+			var isObj = Reflect.isObject(v) && !Api.is(v, String) && !Api.is(v, Array);
 			if( isObj ) {
 				var n = node.getChildByName(f);
 				if( n != null ) {

--- a/hxd/res/DynamicText.hx
+++ b/hxd/res/DynamicText.hx
@@ -8,6 +8,7 @@ import haxe.xml.Fast in Access;
 #else
 import haxe.xml.Access;
 #end
+import hxd.impl.Api;
 
 typedef DynamicTextMeta = Map<String,DynamicTextMetaContent>;
 typedef DynamicTextMetaContent = { skip : Bool, sub : DynamicTextMeta };
@@ -83,7 +84,7 @@ class DynamicText {
 			onMissing(path, "is missing");
 			return null;
 		}
-		if( Std.is(old,Array) ) {
+		if( Api.is(old,Array) ) {
 			onMissing(path,"should be a group");
 			return null;
 		}
@@ -154,23 +155,23 @@ class DynamicText {
 						path.pop();
 						continue;
 					}
-					if( Std.is(sub,String) ) {
+					if( Api.is(sub,String) ) {
 						onMissing(path,"should be a text and not a group");
 						path.pop();
 						continue;
 					}
 					// build structure
 					var ref = ref == null ? null : refIds.get(id);
-					if( Std.is(sub,Array) ) {
+					if( Api.is(sub,Array) ) {
 						var elements : Array<Dynamic> = sub;
 						var data = [for( e in x.elements ) e];
 						var dataRef = ref == null ? null : [for( e in ref.elements ) e];
 						for( i in 0...elements.length ) {
 							var e = elements[i];
 							path.push("[" + i + "]");
-							if( Std.is(e, Array) ) {
+							if( Api.is(e, Array) ) {
 								trace("TODO");
-							} else if( Std.is(e, String) ) {
+							} else if( Api.is(e, String) ) {
 								var enew = applyText(path, e, data[i], dataRef == null ? null : dataRef[i], onMissing);
 								if( enew != null )
 									elements[i] = enew;
@@ -210,12 +211,12 @@ class DynamicText {
 				for( e in x.elements ) {
 					var v : Dynamic = parseXmlData(e);
 					if( isArray ) {
-						if( !Std.is(v, Array) ) v = [v];
+						if( !Api.is(v, Array) ) v = [v];
 					} else {
-						if( Std.is(v, Array) ) {
+						if( Api.is(v, Array) ) {
 							for( i in 0...a.length ) {
 								var v = a[i];
-								if( !Std.is(v, Array) )
+								if( !Api.is(v, Array) )
 									a[i] = [v];
 							}
 							isArray = true;

--- a/hxd/snd/LoadingData.hx
+++ b/hxd/snd/LoadingData.hx
@@ -11,7 +11,7 @@ class LoadingData extends Data {
 
 	override function decode(out:haxe.io.Bytes, outPos:Int, sampleStart:Int, sampleCount:Int):Void {
 		var d = snd.getData();
-		if( Std.is(d, LoadingData) )
+		if( hxd.impl.Api.is(d, LoadingData) )
 			throw "Sound data is not yet available, use load() first";
 		d.decode(out, outPos, sampleStart, sampleCount);
 	}
@@ -20,7 +20,7 @@ class LoadingData extends Data {
 		if( waitCount > 10 )
 			throw "Failed to load data";
 		var d = snd.getData();
-		if( Std.is(d, LoadingData) ) {
+		if( hxd.impl.Api.is(d, LoadingData) ) {
 			waitCount++;
 			haxe.Timer.delay(load.bind(onEnd), 100);
 			return;


### PR DESCRIPTION
Added `hxd.impl.Api.is` which replaces `Std.is` calls due to it being deprecated in favor of `Std.isOfType`. Fixes deprecation warnings for upcoming Haxe 4.2 onwards.