### PR TITLE
HXSL: Added texture size method support

### DIFF
--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -207,9 +207,6 @@ enum TGlobal {
 	Texel;
 	TexelLod;
 	TextureSize;
-	TextureSizeLod;
-	ITextureSize;
-	ITextureSizeLod;
 	// ...other texture* operations
 	// constructors
 	ToInt;
@@ -246,9 +243,6 @@ enum TGlobal {
 	ChannelFetch;
 	ChannelFetchLod;
 	ChannelTextureSize;
-	ChannelTextureSizeLod;
-	IChannelTextureSize;
-	IChannelTextureSizeLod;
 	Trace;
 	// instancing
 	VertexID;

--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -205,7 +205,6 @@ enum TGlobal {
 	Texture;
 	TextureLod;
 	Texel;
-	TexelLod;
 	TextureSize;
 	// ...other texture* operations
 	// constructors
@@ -241,7 +240,6 @@ enum TGlobal {
 	ChannelRead;
 	ChannelReadLod;
 	ChannelFetch;
-	ChannelFetchLod;
 	ChannelTextureSize;
 	Trace;
 	// instancing

--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -206,6 +206,10 @@ enum TGlobal {
 	TextureLod;
 	Texel;
 	TexelLod;
+	TextureSize;
+	TextureSizeLod;
+	ITextureSize;
+	ITextureSizeLod;
 	// ...other texture* operations
 	// constructors
 	ToInt;
@@ -241,6 +245,10 @@ enum TGlobal {
 	ChannelReadLod;
 	ChannelFetch;
 	ChannelFetchLod;
+	ChannelTextureSize;
+	ChannelTextureSizeLod;
+	IChannelTextureSize;
+	IChannelTextureSizeLod;
 	Trace;
 	// instancing
 	VertexID;

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -80,12 +80,9 @@ class Checker {
 			case Texel:
 				[
 					{ args : [ { name: "tex", type: TSampler2D }, { name: "pos", type: ivec2 } ], ret: vec4 },
-					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "pos", type: ivec3 } ], ret: vec4 }
-				];
-			case TexelLod:
-				[
+					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "pos", type: ivec3 } ], ret: vec4 },
 					{ args : [ { name: "tex", type: TSampler2D }, { name: "pos", type: ivec2 }, { name: "lod", type: TInt } ], ret: vec4 },
-					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "pos", type: ivec3 }, { name: "lod", type: TInt } ], ret: vec4 }
+					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "pos", type: ivec3 }, { name: "lod", type: TInt } ], ret: vec4 },
 				];
 			case TextureSize:
 				[
@@ -164,9 +161,6 @@ class Checker {
 					{ args : [ { name : "channel", type : TChannel(2) }, { name : "pos", type : ivec2 } ], ret : vec2 },
 					{ args : [ { name : "channel", type : TChannel(3) }, { name : "pos", type : ivec2 } ], ret : vec3 },
 					{ args : [ { name : "channel", type : TChannel(4) }, { name : "pos", type : ivec2 } ], ret : vec4 },
-				];
-			case ChannelFetchLod:
-				[
 					{ args : [ { name : "channel", type : TChannel(1) }, { name : "pos", type : ivec2 }, { name : "lod", type : TInt } ], ret : TFloat },
 					{ args : [ { name : "channel", type : TChannel(2) }, { name : "pos", type : ivec2 }, { name : "lod", type : TInt } ], ret : vec2 },
 					{ args : [ { name : "channel", type : TChannel(3) }, { name : "pos", type : ivec2 }, { name : "lod", type : TInt } ], ret : vec3 },
@@ -909,10 +903,8 @@ class Checker {
 			case ["get", TChannel(_)]: ChannelRead;
 			case ["getLod", TSampler2D|TSampler2DArray|TSamplerCube]: TextureLod;
 			case ["getLod", TChannel(_)]: ChannelReadLod;
-			case ["fetch", TSampler2D|TSampler2DArray]: Texel;
-			case ["fetch", TChannel(_)]: ChannelFetch;
-			case ["fetchLod", TSampler2D|TSampler2DArray]: TexelLod;
-			case ["fetchLod", TChannel(_)]: ChannelFetchLod;
+			case ["fetch"|"fetchLod", TSampler2D|TSampler2DArray]: Texel;
+			case ["fetch"|"fetchLod", TChannel(_)]: ChannelFetch;
 			case ["size", TSampler2D|TSampler2DArray|TSamplerCube]: TextureSize;
 			case ["size", TChannel(_)]: ChannelTextureSize;
 			default: null;

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -92,24 +92,9 @@ class Checker {
 					{ args : [ { name: "tex", type: TSampler2D } ], ret: vec2 },
 					{ args : [ { name: "tex", type: TSampler2DArray } ], ret: vec3 },
 					{ args : [ { name: "tex", type: TSamplerCube } ], ret: vec2 },
-				];
-			case TextureSizeLod:
-				[
 					{ args : [ { name: "tex", type: TSampler2D }, { name: "lod", type: TInt } ], ret: vec2 },
 					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "lod", type: TInt } ], ret: vec3 },
 					{ args : [ { name: "tex", type: TSamplerCube }, { name: "lod", type: TInt } ], ret: vec2 },
-				];
-			case ITextureSize:
-				[
-					{ args : [ { name: "tex", type: TSampler2D } ], ret: ivec2 },
-					{ args : [ { name: "tex", type: TSampler2DArray } ], ret: ivec3 },
-					{ args : [ { name: "tex", type: TSamplerCube } ], ret: ivec2 },
-				];
-			case ITextureSizeLod:
-				[
-					{ args : [ { name: "tex", type: TSampler2D }, { name: "lod", type: TInt } ], ret: ivec2 },
-					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "lod", type: TInt } ], ret: ivec3 },
-					{ args : [ { name: "tex", type: TSamplerCube }, { name: "lod", type: TInt } ], ret: ivec2 },
 				];
 			case ToInt:
 				[for( t in baseType ) { args : [ { name : "value", type : t } ], ret : TInt } ];
@@ -193,27 +178,10 @@ class Checker {
 					{ args : [ { name: "channel", type: TChannel(2) } ], ret: vec2 },
 					{ args : [ { name: "channel", type: TChannel(3) } ], ret: vec2 },
 					{ args : [ { name: "channel", type: TChannel(4) } ], ret: vec2 },
-				];
-			case ChannelTextureSizeLod:
-				[
 					{ args : [ { name: "channel", type: TChannel(1) }, { name : "lod", type : TInt } ], ret: vec2 },
 					{ args : [ { name: "channel", type: TChannel(2) }, { name : "lod", type : TInt } ], ret: vec2 },
 					{ args : [ { name: "channel", type: TChannel(3) }, { name : "lod", type : TInt } ], ret: vec2 },
 					{ args : [ { name: "channel", type: TChannel(4) }, { name : "lod", type : TInt } ], ret: vec2 },
-				];
-			case IChannelTextureSize:
-				[
-					{ args : [ { name: "channel", type: TChannel(1) } ], ret: ivec2 },
-					{ args : [ { name: "channel", type: TChannel(2) } ], ret: ivec2 },
-					{ args : [ { name: "channel", type: TChannel(3) } ], ret: ivec2 },
-					{ args : [ { name: "channel", type: TChannel(4) } ], ret: ivec2 },
-				];
-			case IChannelTextureSizeLod:
-				[
-					{ args : [ { name: "channel", type: TChannel(1) }, { name : "lod", type : TInt } ], ret: ivec2 },
-					{ args : [ { name: "channel", type: TChannel(2) }, { name : "lod", type : TInt } ], ret: ivec2 },
-					{ args : [ { name: "channel", type: TChannel(3) }, { name : "lod", type : TInt } ], ret: ivec2 },
-					{ args : [ { name: "channel", type: TChannel(4) }, { name : "lod", type : TInt } ], ret: ivec2 },
 				];
 			case ScreenToUv:
 				[{ args : [{ name : "screenPos", type : vec2 }], ret : vec2 }];
@@ -947,12 +915,6 @@ class Checker {
 			case ["fetchLod", TChannel(_)]: ChannelFetchLod;
 			case ["size", TSampler2D|TSampler2DArray|TSamplerCube]: TextureSize;
 			case ["size", TChannel(_)]: ChannelTextureSize;
-			case ["sizeLod", TSampler2D|TSampler2DArray|TSamplerCube]: TextureSizeLod;
-			case ["sizeLod", TChannel(_)]: ChannelTextureSizeLod;
-			case ["isize", TSampler2D|TSampler2DArray|TSamplerCube]: ITextureSize;
-			case ["isize", TChannel(_)]: IChannelTextureSize;
-			case ["isizeLod", TSampler2D|TSampler2DArray|TSamplerCube]: ITextureSizeLod;
-			case ["isizeLod", TChannel(_)]: IChannelTextureSizeLod;
 			default: null;
 			}
 			if( gl != null ) {

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -87,6 +87,30 @@ class Checker {
 					{ args : [ { name: "tex", type: TSampler2D }, { name: "pos", type: ivec2 }, { name: "lod", type: TInt } ], ret: vec4 },
 					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "pos", type: ivec3 }, { name: "lod", type: TInt } ], ret: vec4 }
 				];
+			case TextureSize:
+				[
+					{ args : [ { name: "tex", type: TSampler2D } ], ret: vec2 },
+					{ args : [ { name: "tex", type: TSampler2DArray } ], ret: vec3 },
+					{ args : [ { name: "tex", type: TSamplerCube } ], ret: vec2 },
+				];
+			case TextureSizeLod:
+				[
+					{ args : [ { name: "tex", type: TSampler2D }, { name: "lod", type: TInt } ], ret: vec2 },
+					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "lod", type: TInt } ], ret: vec3 },
+					{ args : [ { name: "tex", type: TSamplerCube }, { name: "lod", type: TInt } ], ret: vec2 },
+				];
+			case ITextureSize:
+				[
+					{ args : [ { name: "tex", type: TSampler2D } ], ret: ivec2 },
+					{ args : [ { name: "tex", type: TSampler2DArray } ], ret: ivec3 },
+					{ args : [ { name: "tex", type: TSamplerCube } ], ret: ivec2 },
+				];
+			case ITextureSizeLod:
+				[
+					{ args : [ { name: "tex", type: TSampler2D }, { name: "lod", type: TInt } ], ret: ivec2 },
+					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "lod", type: TInt } ], ret: ivec3 },
+					{ args : [ { name: "tex", type: TSamplerCube }, { name: "lod", type: TInt } ], ret: ivec2 },
+				];
 			case ToInt:
 				[for( t in baseType ) { args : [ { name : "value", type : t } ], ret : TInt } ];
 			case ToFloat:
@@ -162,6 +186,34 @@ class Checker {
 					{ args : [ { name : "channel", type : TChannel(2) }, { name : "pos", type : ivec2 }, { name : "lod", type : TInt } ], ret : vec2 },
 					{ args : [ { name : "channel", type : TChannel(3) }, { name : "pos", type : ivec2 }, { name : "lod", type : TInt } ], ret : vec3 },
 					{ args : [ { name : "channel", type : TChannel(4) }, { name : "pos", type : ivec2 }, { name : "lod", type : TInt } ], ret : vec4 },
+				];
+			case ChannelTextureSize:
+				[
+					{ args : [ { name: "channel", type: TChannel(1) } ], ret: vec2 },
+					{ args : [ { name: "channel", type: TChannel(2) } ], ret: vec2 },
+					{ args : [ { name: "channel", type: TChannel(3) } ], ret: vec2 },
+					{ args : [ { name: "channel", type: TChannel(4) } ], ret: vec2 },
+				];
+			case ChannelTextureSizeLod:
+				[
+					{ args : [ { name: "channel", type: TChannel(1) }, { name : "lod", type : TInt } ], ret: vec2 },
+					{ args : [ { name: "channel", type: TChannel(2) }, { name : "lod", type : TInt } ], ret: vec2 },
+					{ args : [ { name: "channel", type: TChannel(3) }, { name : "lod", type : TInt } ], ret: vec2 },
+					{ args : [ { name: "channel", type: TChannel(4) }, { name : "lod", type : TInt } ], ret: vec2 },
+				];
+			case IChannelTextureSize:
+				[
+					{ args : [ { name: "channel", type: TChannel(1) } ], ret: ivec2 },
+					{ args : [ { name: "channel", type: TChannel(2) } ], ret: ivec2 },
+					{ args : [ { name: "channel", type: TChannel(3) } ], ret: ivec2 },
+					{ args : [ { name: "channel", type: TChannel(4) } ], ret: ivec2 },
+				];
+			case IChannelTextureSizeLod:
+				[
+					{ args : [ { name: "channel", type: TChannel(1) }, { name : "lod", type : TInt } ], ret: ivec2 },
+					{ args : [ { name: "channel", type: TChannel(2) }, { name : "lod", type : TInt } ], ret: ivec2 },
+					{ args : [ { name: "channel", type: TChannel(3) }, { name : "lod", type : TInt } ], ret: ivec2 },
+					{ args : [ { name: "channel", type: TChannel(4) }, { name : "lod", type : TInt } ], ret: ivec2 },
 				];
 			case ScreenToUv:
 				[{ args : [{ name : "screenPos", type : vec2 }], ret : vec2 }];
@@ -893,6 +945,14 @@ class Checker {
 			case ["fetch", TChannel(_)]: ChannelFetch;
 			case ["fetchLod", TSampler2D|TSampler2DArray]: TexelLod;
 			case ["fetchLod", TChannel(_)]: ChannelFetchLod;
+			case ["size", TSampler2D|TSampler2DArray|TSamplerCube]: TextureSize;
+			case ["size", TChannel(_)]: ChannelTextureSize;
+			case ["sizeLod", TSampler2D|TSampler2DArray|TSamplerCube]: TextureSizeLod;
+			case ["sizeLod", TChannel(_)]: ChannelTextureSizeLod;
+			case ["isize", TSampler2D|TSampler2DArray|TSamplerCube]: ITextureSize;
+			case ["isize", TChannel(_)]: IChannelTextureSize;
+			case ["isizeLod", TSampler2D|TSampler2DArray|TSamplerCube]: ITextureSizeLod;
+			case ["isizeLod", TChannel(_)]: IChannelTextureSizeLod;
 			default: null;
 			}
 			if( gl != null ) {

--- a/hxsl/Dce.hx
+++ b/hxsl/Dce.hx
@@ -238,6 +238,18 @@ class Dce {
 		case TCall({ e : TGlobal(ChannelFetchLod) }, [_, pos, lod, { e : TConst(CInt(cid)) }]):
 			var c = channelVars[cid];
 			return { e : TCall({ e : TGlobal(Texel), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(pos,true), mapExpr(lod,true)]), t : TVoid, p : e.p };
+		case TCall({ e : TGlobal(ChannelTextureSize) }, [_, { e : TConst(CInt(cid)) }]):
+			var c = channelVars[cid];
+			return { e : TCall({ e : TGlobal(TextureSize), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }]), t : TVoid, p : e.p };
+		case TCall({ e : TGlobal(ChannelTextureSizeLod) }, [_, lod, { e : TConst(CInt(cid)) }]):
+			var c = channelVars[cid];
+			return { e : TCall({ e : TGlobal(TextureSizeLod), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(lod,true)]), t : TVoid, p : e.p };
+		case TCall({ e : TGlobal(IChannelTextureSize) }, [_, { e : TConst(CInt(cid)) }]):
+			var c = channelVars[cid];
+			return { e : TCall({ e : TGlobal(ITextureSize), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }]), t : TVoid, p : e.p };
+		case TCall({ e : TGlobal(IChannelTextureSizeLod) }, [_, lod, { e : TConst(CInt(cid)) }]):
+			var c = channelVars[cid];
+			return { e : TCall({ e : TGlobal(ITextureSizeLod), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(lod,true)]), t : TVoid, p : e.p };
 		case TIf(e, econd, eelse):
 			var e = mapExpr(e, true);
 			var econd = mapExpr(econd, isVar);

--- a/hxsl/Dce.hx
+++ b/hxsl/Dce.hx
@@ -235,7 +235,7 @@ class Dce {
 		case TCall({ e : TGlobal(ChannelFetch) }, [_, pos, { e : TConst(CInt(cid)) }]):
 			var c = channelVars[cid];
 			return { e : TCall({ e : TGlobal(Texel), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(pos,true)]), t : TVoid, p : e.p };
-		case TCall({ e : TGlobal(ChannelFetchLod) }, [_, pos, lod, { e : TConst(CInt(cid)) }]):
+		case TCall({ e : TGlobal(ChannelFetch) }, [_, pos, lod, { e : TConst(CInt(cid)) }]):
 			var c = channelVars[cid];
 			return { e : TCall({ e : TGlobal(Texel), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(pos,true), mapExpr(lod,true)]), t : TVoid, p : e.p };
 		case TCall({ e : TGlobal(ChannelTextureSize) }, [_, { e : TConst(CInt(cid)) }]):

--- a/hxsl/Dce.hx
+++ b/hxsl/Dce.hx
@@ -241,15 +241,9 @@ class Dce {
 		case TCall({ e : TGlobal(ChannelTextureSize) }, [_, { e : TConst(CInt(cid)) }]):
 			var c = channelVars[cid];
 			return { e : TCall({ e : TGlobal(TextureSize), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }]), t : TVoid, p : e.p };
-		case TCall({ e : TGlobal(ChannelTextureSizeLod) }, [_, lod, { e : TConst(CInt(cid)) }]):
+		case TCall({ e : TGlobal(ChannelTextureSize) }, [_, lod, { e : TConst(CInt(cid)) }]):
 			var c = channelVars[cid];
-			return { e : TCall({ e : TGlobal(TextureSizeLod), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(lod,true)]), t : TVoid, p : e.p };
-		case TCall({ e : TGlobal(IChannelTextureSize) }, [_, { e : TConst(CInt(cid)) }]):
-			var c = channelVars[cid];
-			return { e : TCall({ e : TGlobal(ITextureSize), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }]), t : TVoid, p : e.p };
-		case TCall({ e : TGlobal(IChannelTextureSizeLod) }, [_, lod, { e : TConst(CInt(cid)) }]):
-			var c = channelVars[cid];
-			return { e : TCall({ e : TGlobal(ITextureSizeLod), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(lod,true)]), t : TVoid, p : e.p };
+			return { e : TCall({ e : TGlobal(TextureSize), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(lod,true)]), t : TVoid, p : e.p };
 		case TIf(e, econd, eelse):
 			var e = mapExpr(e, true);
 			var econd = mapExpr(econd, isVar);

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -255,7 +255,7 @@ class GlslOut {
 				return "textureCubeLodEXT";
 			default:
 			}
-		case Texel, TexelLod:
+		case Texel:
 			// if ( isES2 )
 			// 	decl("vec4 _texelFetch(sampler2d tex, ivec2 pos, int lod) ...")
 			// 	return "_texelFetch";
@@ -389,11 +389,17 @@ class GlslOut {
 		case TCall({ e : TGlobal(g = Texel) }, args):
 			add(getFunName(g,args,e.t));
 			add("(");
-			for( e in args ) {
-				addValue(e, tabs);
+			addValue(args[0], tabs); // sampler
+			add(", ");
+			addValue(args[1], tabs); // uv
+			if ( args.length != 2 ) {
+				// with LOD argument
 				add(", ");
+				addValue(args[2], tabs);
+				add(")");
+			} else {
+				add(", 0)");
 			}
-			add("0)");
 		case TCall({ e : TGlobal(g = TextureSize) }, args):
 			add(getFunName(g,args,e.t));
 			add("(");

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -261,16 +261,11 @@ class GlslOut {
 			// 	return "_texelFetch";
 			// else
 				return "texelFetch";
-		case TextureSize, TextureSizeLod:
+		case TextureSize:
 			decl("vec2 _textureSize(sampler2D sampler, int lod) { return vec2(textureSize(sampler, lod)); }");
 			decl("vec3 _textureSize(sampler2DArray sampler, int lod) { return vec3(textureSize(sampler, lod)); }");
 			decl("vec2 _textureSize(samplerCube sampler, int lod) { return vec2(textureSize(sampler, lod)); }");
 			return "_textureSize";
-		case ITextureSize, ITextureSizeLod:
-			// if ( isES2 )
-			// 	decl...
-			// else
-				return "textureSize";
 		case Mod if( rt == TInt && isES ):
 			decl("int _imod( int x, int y ) { return int(mod(float(x),float(y))); }");
 			return "_imod";
@@ -391,7 +386,7 @@ class GlslOut {
 			add("clamp(");
 			addValue(e, tabs);
 			add(", 0., 1.)");
-		case TCall({ e : TGlobal(g = Texel | TextureSize | ITextureSize) }, args):
+		case TCall({ e : TGlobal(g = Texel) }, args):
 			add(getFunName(g,args,e.t));
 			add("(");
 			for( e in args ) {
@@ -399,6 +394,18 @@ class GlslOut {
 				add(", ");
 			}
 			add("0)");
+		case TCall({ e : TGlobal(g = TextureSize) }, args):
+			add(getFunName(g,args,e.t));
+			add("(");
+			addValue(args[0], tabs);
+			if ( args.length != 1 ) {
+				// with LOD argument
+				add(", ");
+				addValue(args[1], tabs);
+				add(")");
+			} else {
+				add(", 0)");
+			}
 		case TCall(v, args):
 			switch( v.e ) {
 			case TGlobal(g):

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -261,6 +261,16 @@ class GlslOut {
 			// 	return "_texelFetch";
 			// else
 				return "texelFetch";
+		case TextureSize, TextureSizeLod:
+			decl("vec2 _textureSize(sampler2D sampler, int lod) { return vec2(textureSize(sampler, lod)); }");
+			decl("vec3 _textureSize(sampler2DArray sampler, int lod) { return vec3(textureSize(sampler, lod)); }");
+			decl("vec2 _textureSize(samplerCube sampler, int lod) { return vec2(textureSize(sampler, lod)); }");
+			return "_textureSize";
+		case ITextureSize, ITextureSizeLod:
+			// if ( isES2 )
+			// 	decl...
+			// else
+				return "textureSize";
 		case Mod if( rt == TInt && isES ):
 			decl("int _imod( int x, int y ) { return int(mod(float(x),float(y))); }");
 			return "_imod";
@@ -381,7 +391,7 @@ class GlslOut {
 			add("clamp(");
 			addValue(e, tabs);
 			add(", 0., 1.)");
-		case TCall({ e : TGlobal(g = Texel) }, args):
+		case TCall({ e : TGlobal(g = Texel | TextureSize | ITextureSize) }, args):
 			add(getFunName(g,args,e.t));
 			add("(");
 			for( e in args ) {

--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -287,6 +287,34 @@ class HlslOut {
 					throw "assert";
 			}
 			add("))");
+		case TCall({ e : TGlobal(g = (TextureSize | TextureSizeLod)) }, args):
+			decl("float2 textureSize(Texture2D tex) { float w; float h; tex.GetDimensions(tex, out w, out h); return float2(w, h); }");
+			decl("float3 textureSize(Texture2DArray tex) { float w; float h; float els; tex.GetDimensions(tex, out w, out h, out els); return float3(w, h, els); }");
+			decl("float2 textureSize(TextureCube tex) { float w; float h; tex.GetDimensions(tex, out w, out h); return float2(w, h); }");
+			decl("float2 textureSize(Texture2D tex, int lod) { float w; float h; tex.GetDimensions(tex, (uint)lod, out w, out h); return float2(w, h); }");
+			decl("float3 textureSize(Texture2DArray tex, int lod) { float w; float h; float els; tex.GetDimensions(tex, (uint)lod, out w, out h, out els); return float3(w, h, els); }");
+			decl("float2 textureSize(TextureCube tex, int lod) { float w; float h; tex.GetDimensions(tex, (uint)lod, out w, out h); return float2(w, h); }");
+			add("textureSize(");
+			addValue(args[0], tabs);
+			if ( g == TextureSizeLod || g == ITextureSizeLod) {
+				add(", ");
+				addValue(args[1],tabs);
+			}
+			add(")");
+		case TCall({ e : TGlobal(g = (ITextureSize | ITextureSizeLod)) }, args):
+			decl("int2 textureSize(Texture2D tex) { uint w; uint h; tex.GetDimensions(tex, out w, out h); return int2((int)w, (int)h); }");
+			decl("int3 textureSize(Texture2DArray tex) { uint w; uint h; uint els; tex.GetDimensions(tex, out w, out h, out els); return int3((int)w, (int)h, (int)els); }");
+			decl("int2 textureSize(TextureCube tex) { uint w; uint h; tex.GetDimensions(tex, out w, out h); return int2((int)w, (int)h); }");
+			decl("int2 textureSize(Texture2D tex, int lod) { uint w; uint h; tex.GetDimensions(tex, (uint)lod, out w, out h); return int2((int)w, (int)h); }");
+			decl("int3 textureSize(Texture2DArray tex, int lod) { uint w; uint h; uint els; tex.GetDimensions(tex, (uint) lod, out w, out h, out els); return int3((int)w, (int)h, (int)els); }");
+			decl("int2 textureSize(TextureCube tex, int lod) { uint w; uint h; tex.GetDimensions(tex, (uint)lod, out w, out h); return int2((int)w, (int)h); }");
+			add("textureSize(");
+			addValue(args[0], tabs);
+			if ( g == TextureSizeLod || g == ITextureSizeLod) {
+				add(", ");
+				addValue(args[1],tabs);
+			}
+			add(")");
 		case TCall(e = { e : TGlobal(g) }, args):
 			switch( [g,args.length] ) {
 			case [Vec2, 1] if( args[0].t == TFloat ):

--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -265,7 +265,7 @@ class HlslOut {
 			if( g == Texture && isVertex )
 				add(",0");
 			add(")");
-		case TCall({ e : TGlobal(g = (Texel | TexelLod)) }, args):
+		case TCall({ e : TGlobal(g = (Texel)) }, args):
 			addValue(args[0], tabs);
 			add(".Load(");
 			switch ( args[1].t ) {
@@ -277,14 +277,12 @@ class HlslOut {
 					throw "assert";
 			}
 			addValue(args[1],tabs);
-			switch( g ) {
-				case Texel:
-					add(", 0");
-				case TexelLod:
-					add(", ");
-					addValue(args[2],tabs);
-				default:
-					throw "assert";
+			if ( args.length != 2 ) {
+				// with LOD argument
+				add(", ");
+				addValue(args[2], tabs);
+			} else {
+				add(", 0");
 			}
 			add("))");
 		case TCall({ e : TGlobal(g = (TextureSize)) }, args):

--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -287,32 +287,18 @@ class HlslOut {
 					throw "assert";
 			}
 			add("))");
-		case TCall({ e : TGlobal(g = (TextureSize | TextureSizeLod)) }, args):
-			decl("float2 textureSize(Texture2D tex) { float w; float h; tex.GetDimensions(tex, out w, out h); return float2(w, h); }");
-			decl("float3 textureSize(Texture2DArray tex) { float w; float h; float els; tex.GetDimensions(tex, out w, out h, out els); return float3(w, h, els); }");
-			decl("float2 textureSize(TextureCube tex) { float w; float h; tex.GetDimensions(tex, out w, out h); return float2(w, h); }");
+		case TCall({ e : TGlobal(g = (TextureSize)) }, args):
 			decl("float2 textureSize(Texture2D tex, int lod) { float w; float h; tex.GetDimensions(tex, (uint)lod, out w, out h); return float2(w, h); }");
 			decl("float3 textureSize(Texture2DArray tex, int lod) { float w; float h; float els; tex.GetDimensions(tex, (uint)lod, out w, out h, out els); return float3(w, h, els); }");
 			decl("float2 textureSize(TextureCube tex, int lod) { float w; float h; tex.GetDimensions(tex, (uint)lod, out w, out h); return float2(w, h); }");
 			add("textureSize(");
 			addValue(args[0], tabs);
-			if ( g == TextureSizeLod || g == ITextureSizeLod) {
+			if (args.length != 1) {
+				// With LOD argument
 				add(", ");
 				addValue(args[1],tabs);
-			}
-			add(")");
-		case TCall({ e : TGlobal(g = (ITextureSize | ITextureSizeLod)) }, args):
-			decl("int2 textureSize(Texture2D tex) { uint w; uint h; tex.GetDimensions(tex, out w, out h); return int2((int)w, (int)h); }");
-			decl("int3 textureSize(Texture2DArray tex) { uint w; uint h; uint els; tex.GetDimensions(tex, out w, out h, out els); return int3((int)w, (int)h, (int)els); }");
-			decl("int2 textureSize(TextureCube tex) { uint w; uint h; tex.GetDimensions(tex, out w, out h); return int2((int)w, (int)h); }");
-			decl("int2 textureSize(Texture2D tex, int lod) { uint w; uint h; tex.GetDimensions(tex, (uint)lod, out w, out h); return int2((int)w, (int)h); }");
-			decl("int3 textureSize(Texture2DArray tex, int lod) { uint w; uint h; uint els; tex.GetDimensions(tex, (uint) lod, out w, out h, out els); return int3((int)w, (int)h, (int)els); }");
-			decl("int2 textureSize(TextureCube tex, int lod) { uint w; uint h; tex.GetDimensions(tex, (uint)lod, out w, out h); return int2((int)w, (int)h); }");
-			add("textureSize(");
-			addValue(args[0], tabs);
-			if ( g == TextureSizeLod || g == ITextureSizeLod) {
-				add(", ");
-				addValue(args[1],tabs);
+			} else {
+				add(", 0");
 			}
 			add(")");
 		case TCall(e = { e : TGlobal(g) }, args):


### PR DESCRIPTION
Added support for `sampler.size()` and `sampler.isize()` methods that return `vec` and `ivec` respectively with the texture dimensions. 
For Sampler2D and SamplerCube it's `vec2` and Sampler2DArray is `vec3` with Z being element count.
As with `fetch`, there is no support for GLES2.0, since I have no idea how to implement hidden uniform with texture size as a substitute.  