### PR TITLE
Mark base2d texture as shared

### DIFF
--- a/h3d/shader/Base2d.hx
+++ b/h3d/shader/Base2d.hx
@@ -17,7 +17,7 @@ class Base2d extends hxsl.Shader {
 
 		@global var time : Float;
 		@param var zValue : Float;
-		@param var texture : Sampler2D;
+		@shared @param var texture : Sampler2D;
 
 		var spritePosition : Vec4;
 		var absolutePosition : Vec4;

--- a/h3d/shader/Base2d.hx
+++ b/h3d/shader/Base2d.hx
@@ -26,7 +26,7 @@ class Base2d extends hxsl.Shader {
 		@var var calculatedUV : Vec2;
 
 		@const var isRelative : Bool;
-		@param var color : Vec4;
+		@shared @param var color : Vec4;
 		@param var absoluteMatrixA : Vec3;
 		@param var absoluteMatrixB : Vec3;
 		@param var filterMatrixA : Vec3;


### PR DESCRIPTION
Reasoning: Since I discovered the `@shared` qualifier, I seriously wondered why base2d does not expose its texture, since it would allow simplification of shaders by omitting double-passing of same texture during rendering of 2d elements that performs multiple texture samples. And with introduction of `.size()` support, I decided to mark it as shared.

Here's an example of shader that uses both new `.size()` feature and shared texture of Base2d to produce subpixel antialiasing (useful for PA games, and requires setting `smooth = true`):
```haxe
package h3d.shader;

class PixelartAA extends hxsl.Shader {
	
	static var SRC = {
		
		var texture : Sampler2D;
		@var var calculatedUV:Vec2;

		function subpixelAA(uv:Vec2):Vec2 {
			var size = texture.size();
			var deriv = fwidth(uv) * .5;
			var uvmin = (uv - deriv) * size; // top-left edge of the screen pixel
			var uvmax = (uv + deriv) * size; // bottom-right edge of the screen pixel
			var fmax = floor(uvmax);
			var t = (fmax - uvmin) / (uvmax - uvmin) * (fmax - floor(uvmin));
			uv = ((fmax + 0.5 - t) / size);
		}

		function __init__fragment() {
			calculatedUV = subpixelAA(calculatedUV);
		}

	}

}
```
Also question: Should I PR that shader in, or it's too specific of a shader for stock Heaps? :) 