### PR TITLE
fix: prevent double sound queuing

### DIFF
--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -337,7 +337,7 @@ class Manager {
 					c.position = (lastBuffer.start + lastBuffer.samples) / lastBuffer.sampleRate;
 					releaseSource(s);
 				} else if (c.queue.length > 0) {
-					c.sound    = c.queue[0];
+					c.sound    = c.queue.shift();
 					c.duration = c.sound.getData().duration;
 					c.position = 0;
 					releaseSource(s);


### PR DESCRIPTION
while queuing sound in channel onEnd