### PR TITLE
Fix Convert version not being updated

### DIFF
--- a/hxd/fs/FileConverter.hx
+++ b/hxd/fs/FileConverter.hx
@@ -321,6 +321,7 @@ class FileConverter {
 		if( !sys.FileSystem.exists(fullOutPath) )
 			throw "Converted output file "+fullOutPath+" was not created";
 
+		match.ver = conv.version;
 		match.time = time;
 		match.hash = hash;
 		saveCache();


### PR DESCRIPTION
Fixes bug when Convert was ran every time if Convert happened on already converted file due to Convert version mismatch, because db file never updated the version value.