### PR TITLE
HXSL: Implement borrow qualifier

### DIFF
--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -385,7 +385,7 @@ class Tools {
 		if ( v.qualifiers != null )
 			for( q in v.qualifiers )
 				switch (q) {
-					case Borrow(s): return StringTools.startsWith(path, s);
+					case Borrow(s): return path == s;
 					default:
 				}
 		return false;

--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -84,6 +84,7 @@ enum VarQualifier {
 	Ignore; // the variable is ignored in reflection (inspector)
 	PerInstance( v : Int );
 	Doc( s : String );
+	Borrow( source : String );
 }
 
 enum Prec {
@@ -377,6 +378,16 @@ class Tools {
 			for( q2 in v.qualifiers )
 				if( q2 == q )
 					return true;
+		return false;
+	}
+
+	public static function hasBorrowQualifier( v : TVar, path : String ) {
+		if ( v.qualifiers != null )
+			for( q in v.qualifiers )
+				switch (q) {
+					case Borrow(s): return StringTools.startsWith(path, s);
+					default:
+				}
 		return false;
 	}
 

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -809,6 +809,8 @@ class Checker {
 					default:
 						error("Precision qualifier not supported on " + v.type, pos);
 					}
+				case Borrow(source):
+					if ( v.kind != Local ) error("Borrow should not have a type qualifier", pos);
 				case Ignore, Doc(_):
 				}
 		}

--- a/hxsl/Linker.hx
+++ b/hxsl/Linker.hx
@@ -8,6 +8,7 @@ private class AllocatedVar {
 	public var merged : Array<TVar>;
 	public var kind : Null<FunctionKind>;
 	public var parent : AllocatedVar;
+	public var rootShaderName : String;
 	public var instanceIndex : Int;
 	public function new() {
 	}
@@ -68,10 +69,31 @@ class Linker {
 		return Error.t(msg, p);
 	}
 
-	function mergeVar( path : String, v : TVar, v2 : TVar, p : Position ) {
+	function mergeVar( path : String, v : TVar, v2 : TVar, p : Position, shaderName : String ) {
 		switch( v.kind ) {
 		case Global, Input, Var, Local, Output:
 			// shared vars
+		case Param if ( shaderName != null ):
+			var valid = false;
+			for ( q in v.qualifiers ) {
+				switch (q) {
+					case Borrow(source):
+						if ( StringTools.startsWith(shaderName, source) )
+							valid = true;
+						break;
+					default:
+				}
+			}
+			for ( q in v2.qualifiers ) {
+				switch (q) {
+					case Borrow(source):
+						if ( StringTools.startsWith(shaderName, source) )
+							valid = true;
+						break;
+					default:
+				}
+			}
+			if (!valid) throw "assert";
 		case Param, Function:
 			throw "assert";
 		}
@@ -88,9 +110,9 @@ class Linker {
 					}
 				// add a new field
 				if( ft == null )
-					fl2.push(allocVar(f1,p).v);
+					fl2.push(allocVar(f1,p, null, null, shaderName).v);
 				else
-					mergeVar(path + "." + ft.name, f1, ft, p);
+					mergeVar(path + "." + ft.name, f1, ft, p, shaderName);
 			}
 		default:
 			if( !v.type.equals(v2.type) )
@@ -98,9 +120,9 @@ class Linker {
 		}
 	}
 
-	function allocVar( v : TVar, p : Position, ?path : String, ?parent : AllocatedVar ) : AllocatedVar {
+	function allocVar( v : TVar, p : Position, ?path : String, ?parent : AllocatedVar, ?shaderName : String ) : AllocatedVar {
 		if( v.parent != null && parent == null ) {
-			parent = allocVar(v.parent, p);
+			parent = allocVar(v.parent, p, null, null, shaderName);
 			var p = parent.v;
 			path = p.name;
 			p = p.parent;
@@ -122,10 +144,10 @@ class Linker {
 			for( vm in v2.merged )
 				if( vm == v )
 					return v2;
-			inline function isUnique( v : TVar ) {
-				return (v.kind == Param && !v.hasQualifier(Shared) && !isBatchShader) || v.kind == Function || (v.kind == Var && v.hasQualifier(Private));
+			inline function isUnique( v : TVar, borrowed : Bool ) {
+				return (v.kind == Param && !borrowed && !v.hasQualifier(Shared) && !isBatchShader) || v.kind == Function || (v.kind == Var && v.hasQualifier(Private));
 			}
-			if( isUnique(v) || isUnique(v2.v) || (v.kind == Param && v2.v.kind == Param) /* two shared : one takes priority */ ) {
+			if( isUnique(v, v2.v.hasBorrowQualifier(shaderName)) || isUnique(v2.v, v.hasBorrowQualifier(v2.rootShaderName)) || (v.kind == Param && v2.v.kind == Param) /* two shared : one takes priority */ ) {
 				// allocate a new unique name in the shader if already in use
 				var k = 2;
 				while( true ) {
@@ -140,7 +162,7 @@ class Linker {
 				key += k;
 			} else {
 				v2.merged.push(v);
-				mergeVar(key, v, v2.v, p);
+				mergeVar(key, v, v2.v, p, v2.rootShaderName);
 				varIdMap.set(v.id, v2.id);
 				return v2;
 			}
@@ -161,11 +183,12 @@ class Linker {
 		a.id = vid;
 		a.parent = parent;
 		a.instanceIndex = curInstance;
+		a.rootShaderName = shaderName;
 		allVars.push(a);
 		varMap.set(key, a);
 		switch( v2.type ) {
 		case TStruct(vl):
-			v2.type = TStruct([for( v in vl ) allocVar(v, p, key, a).v]);
+			v2.type = TStruct([for( v in vl ) allocVar(v, p, key, a, shaderName).v]);
 		default:
 		}
 		return a;
@@ -356,7 +379,7 @@ class Linker {
 		for( s in shadersData ) {
 			isBatchShader = batchMode && StringTools.startsWith(s.name,"batchShader_");
 			for( v in s.vars ) {
-				var v2 = allocVar(v, null);
+				var v2 = allocVar(v, null, null, null, s.name);
 				if( isBatchShader && v2.v.kind == Param && !StringTools.startsWith(v2.path,"Batch_") )
 					v2.v.kind = Local;
 				if( v.kind == Output ) outVars.push(v);

--- a/hxsl/MacroParser.hx
+++ b/hxsl/MacroParser.hx
@@ -29,6 +29,20 @@ class MacroParser {
 		case [ { expr: EConst(CString(s)), pos: pos } ] if (m.name == "doc"):
 			v.qualifiers.push(Doc(s));
 			return;
+		case [ e ] if (m.name == "borrow"):
+			var path = [];
+			function loop( e : Expr ) {
+				switch( e.expr ) {
+				case EConst(CIdent(s)): path.push(s);
+				case EConst(CString(s)): path.push(s);
+				case EField(e, f): loop(e); path.push(f);
+				default:
+					error("Should be a shader type path", e.pos);
+				}
+			}
+			loop(e);
+			v.qualifiers.push(Borrow(path.join(".")));
+			return;
 		default:
 			error("Invalid meta parameter for "+m.name, m.pos);
 		}

--- a/hxsl/Printer.hx
+++ b/hxsl/Printer.hx
@@ -62,6 +62,7 @@ class Printer {
 				case Ignore: "ignore";
 				case PerInstance(n): "perInstance("+n+")";
 				case Doc(s): "doc(\"" + StringTools.replace(s, '"', '\\"') + "\")";
+				case Borrow(s): "borrow(" + s + ")";
 				}) + " ");
 		}
 		if( v.kind != defKind )

--- a/hxsl/Serializer.hx
+++ b/hxsl/Serializer.hx
@@ -185,6 +185,7 @@ class Serializer {
 				case Range(min, max): out.addDouble(min); out.addDouble(max);
 				case PerInstance(v): out.addInt32(v);
 				case Doc(s): writeString(s);
+				case Borrow(s): writeString(s);
 				}
 			}
 		}
@@ -399,6 +400,7 @@ class Serializer {
 				case 8: Ignore;
 				case 9: PerInstance(input.readInt32());
 				case 10: Doc(readString());
+				case 11: Borrow(readString());
 				default: throw "assert";
 				}
 				v.qualifiers.push(q);


### PR DESCRIPTION
Implements `@borrow(path.to.Shader)` qualifier to variables.
This is essentially reverse of the `@shared` qualifier and intended only for advanced usage. (As pretty much everything HXSL, frankly.) Lets user-defined shaders to borrow uniforms from other shaders. Does not perform checks for that shader actually being attached and is completely on the conscience of the user to ensure shaders they borrow from are present. This a follow up to #912 as an alternative way to access foreign uniforms. 

<details>
<summary>Usage example</summary>

In this shader I already posted before I need to know the texture size of Base2d to perform custom sampling filter transition curve that is specifically made for pixel-art. And "just set texture to what you going to render beforehand" is not a solution.

```haxe
class PixelartAA extends hxsl.Shader {
	
	static var SRC = {
		
		@borrow(h3d.shader.Base2d) var texture : Sampler2D;
		@var var calculatedUV:Vec2;

		function subpixelAA(uv:Vec2):Vec2 {
			var size = texture.size();
			var deriv = fwidth(uv) * .5;
			var uvmin = (uv - deriv) * size; // top-left edge of the screen pixel
			var uvmax = (uv + deriv) * size; // bottom-right edge of the screen pixel
			var fmax = floor(uvmax);
			var t = (fmax - uvmin) / (uvmax - uvmin) * (fmax - floor(uvmin));
			uv = ((fmax + 0.5 - t) / size);
		}

		function __init__fragment() {
			calculatedUV = subpixelAA(calculatedUV);
		}

	}

}
```

</details>

### Reasoning
1. While I understand that shaders are designed to be fairly isolated and communicate only via shared variables, not once I found myself in a need to have access to some `@param`, and so far only solution was to make a duplicate param, and ensure that you set it to same value as the one want data from. And this is clearly not a very good solution.
2. Uniform redundancy is solved this way. If there's something you need to get from uniform that is supplied by another shader in the pipeline - you can borrow it.
3. While feature is undoubtfully dangerous since it can produce runtime compilation errors - it's a thing to many parts of shader pipeline. I think this is a responsibility of the programmer to ensure that all required shaders are in the pipeline, and if not - its their own fault.
4. As many HXSL features - this one will be obscure and unknown to many users (unless I document it, ha), and wont affect vast majority of them, but it introduces more control over the shader pipeline to people who want it. 
5. The "name is common hence can't be marked as `@shared`" is no longer applicable, since borrowing is an explicit action from the user, and it doesn't matter if name is common or not. Especially since it requires to specify which shader it borrows from. I can make it as simple as just `@borrow` but then it's not very clear what it borrows and from where. 

### Extra notes
Because of how duplicate name is implemented, common names are a big problem in general for borrow and shared qualifiers, because those checks happen only for first variable, there are edge cases that can be resolved only by accounting for all variables that were renamed due to naming collision. Such as:
```haxe
// ShaderA
@param var color:Vec4;
// ShaderB
@shared @param var color:Vec4;
// ShaderC
var color:Vec4;
// Output
@param var color:Vec4; // ShaderA
@param var color2:Vec4; // ShaderB
@local var color3:Vec4; // ShaderC
// Expected result
@param var color:Vec4; // ShaderA
@param var color2:Vec4; // ShaderB + ShaderC
```
This wont compile btw, because `color3` is never assigned. Reverse is applicable as well, with `@borrow(ShaderB) var color:Vec4;`
This is obviously because ShaderB, which shares its uniform was processed after ShaderA, which occupied the `color` ID, causing it to be renamed into `color2`, and by the time ShaderC get processed and expects the shared uniform from ShaderB - it gets the `color` that is not marked as shared, causing it to be considered unique, disregarding that `color2` _is_ shared. 