### PR TITLE
Added highDPI flag that enables it when creating a SDL window.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin
 .vscode
 /tools/mikktspace/out
 *.exe
+.DS_store

--- a/h3d/Engine.hx
+++ b/h3d/Engine.hx
@@ -280,7 +280,13 @@ class Engine {
 		if( height < 32 ) height = 32;
 		this.width = width;
 		this.height = height;
-		if( !driver.isDisposed() ) driver.resize(width, height);
+
+		// Set the driver size to actual pixel width
+		// (same as window size on normal displays, differs when high DPI is enabled)
+		var pw = window.pixelWidth;
+		var ph = window.pixelHeight;
+
+		if( !driver.isDisposed() ) driver.resize(pw, ph);
 	}
 
 	public function begin() {

--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -97,6 +97,7 @@ class System {
 		var size = haxe.macro.Compiler.getDefine("windowSize");
 		var title = haxe.macro.Compiler.getDefine("windowTitle");
 		var fixed = haxe.macro.Compiler.getDefine("windowFixed") == "1";
+		var highDPI = haxe.macro.Compiler.getDefine("highDPI") == "1";
 		if( title == null )
 			title = "";
 		if( size != null ) {
@@ -108,10 +109,10 @@ class System {
 		#if hlsdl
 			sdl.Sdl.init();
 			@:privateAccess Window.initChars();
-			@:privateAccess Window.inst = new Window(title, width, height, fixed);
+			@:privateAccess Window.inst = new Window(title, width, height, fixed, highDPI);
 			init();
 		#elseif hldx
-			@:privateAccess Window.inst = new Window(title, width, height, fixed);
+			@:privateAccess Window.inst = new Window(title, width, height, fixed, highDPI);
 			init();
 		#else
 			@:privateAccess Window.inst = new Window(title, width, height);

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -26,6 +26,9 @@ class Window {
 
 	public var width(get, never) : Int;
 	public var height(get, never) : Int;
+	public var pixelWidth(get, never) : Int;
+	public var pixelHeight(get, never) : Int;
+
 	public var mouseX(get, never) : Int;
 	public var mouseY(get, never) : Int;
 	public var mouseLock(get, set) : Bool;
@@ -50,13 +53,16 @@ class Window {
 	static inline var TOUCH_SCALE = #if (hl_ver >= version("1.12.0")) 10000 #else 100 #end;
 	#end
 
-	function new(title:String, width:Int, height:Int, fixed:Bool = false) {
+	function new(title:String, width:Int, height:Int, fixed:Bool = false, highDPI = false) {
 		this.windowWidth = width;
 		this.windowHeight = height;
 		eventTargets = new List();
 		resizeEvents = new List();
 		#if hlsdl
-		final sdlFlags = if (!fixed) sdl.Window.SDL_WINDOW_SHOWN | sdl.Window.SDL_WINDOW_RESIZABLE else sdl.Window.SDL_WINDOW_SHOWN;
+		var sdlFlags = if (!fixed) sdl.Window.SDL_WINDOW_SHOWN | sdl.Window.SDL_WINDOW_RESIZABLE else sdl.Window.SDL_WINDOW_SHOWN;
+		if (highDPI) {
+			sdlFlags |= sdl.Window.SDL_WINDOW_ALLOW_HIGHDPI;
+		}
 		window = new sdl.Window(title, width, height, sdl.Window.SDL_WINDOWPOS_CENTERED, sdl.Window.SDL_WINDOWPOS_CENTERED, sdlFlags);
 		#elseif hldx
 		final dxFlags = if (!fixed) dx.Window.RESIZABLE else 0;
@@ -132,6 +138,14 @@ class Window {
 
 	function get_height() : Int {
 		return windowHeight;
+	}
+	
+	function get_pixelWidth() : Int {
+		return window.pixelWidth;
+	}
+
+	function get_pixelHeight() : Int {
+		return window.pixelHeight;
 	}
 
 	function get_mouseLock() : Bool {

--- a/hxd/Window.hx
+++ b/hxd/Window.hx
@@ -14,6 +14,9 @@ class Window {
 
 	public var width(get, never) : Int;
 	public var height(get, never) : Int;
+	public var pixelWidth(get, never) : Int;
+	public var pixelHeight(get, never) : Int;
+
 	public var mouseX(get, never) : Int;
 	public var mouseY(get, never) : Int;
 	public var mouseLock(get, set) : Bool;
@@ -92,6 +95,13 @@ class Window {
 	}
 
 	function get_height() : Int {
+		return 0;
+	}
+
+	function get_pixelWidth() : Int {
+		return 0;
+	}
+	function get_pixelHeight() : Int {
 		return 0;
 	}
 

--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -14,6 +14,9 @@ class Window {
 
 	public var width(get, never) : Int;
 	public var height(get, never) : Int;
+	public var pixelWidth(get, never) : Int;
+	public var pixelHeight(get, never) : Int;
+
 	public var mouseX(get, never) : Int;
 	public var mouseY(get, never) : Int;
 	public var mouseLock(get, set) : Bool;
@@ -199,6 +202,14 @@ class Window {
 
 	function get_height() {
 		return Math.round(canvasPos.height * getPixelRatio());
+	}
+
+	function get_pixelHeight() {
+		return height;
+	}
+
+	function get_pixelWidth() {
+		return width;
 	}
 
 	function get_mouseX() {


### PR DESCRIPTION
I added a define `-D highDPI`, that will enable it when creating a SDL window.
It will then get the raw pixel size of the screen instead of window size, using `SDL_GL_GetDrawableSize`, and set the render context dimension to that when the window is resized. 

I don't know if this is the correct way to do it, but to me it seems to work quite well.

High DPI flag off:

![image](https://user-images.githubusercontent.com/494817/103922853-aab33880-5114-11eb-890d-5aca932dd433.png)

High DPI flag on:
![image](https://user-images.githubusercontent.com/494817/103922964-ca4a6100-5114-11eb-81c1-0568f110d0b5.png)

Fixes https://github.com/HeapsIO/heaps/issues/589
