### PR TITLE
Add documentation to hxd.fs package

### DIFF
--- a/hxd/fs/BytesFileSystem.hx
+++ b/hxd/fs/BytesFileSystem.hx
@@ -2,12 +2,24 @@ package hxd.fs;
 
 using haxe.io.Path;
 
+/**
+	A Bytes-based file entry.
+
+	Can be used to create resources from outside of the Resource system.
+	For example, assets downloaded over the network or generated at runtime.
+**/
 class BytesFileEntry extends FileEntry {
 
 	var fullPath : String;
 	var bytes : haxe.io.Bytes;
 	var pos : Int;
 
+	/**
+		Create a new BytesFileEntry instance.
+
+		@param path The path of the file.
+		@param bytes The contents of the file.
+	**/
 	public function new(path, bytes) {
 		this.fullPath = path;
 		this.name = path.split("/").pop();
@@ -49,6 +61,7 @@ class BytesFileEntry extends FileEntry {
 		haxe.Timer.delay(onReady, 1);
 	}
 
+	@:dox(show)
 	override function loadBitmap( onLoaded : LoadedBitmap -> Void ) : Void {
 		#if flash
 		var loader = new flash.display.Loader();
@@ -85,34 +98,68 @@ class BytesFileEntry extends FileEntry {
 
 }
 
+/**
+	A base class for custom FileSystem based on preloaded Bytes data.
+
+	As bare minimum, inheriting classes should override the `getBytes`, and ideally `getRoot` and `dir` methods.
+**/
 class BytesFileSystem implements FileSystem {
 
 	function new() {
 	}
 
+	/**
+		Should be overridden by inheriting class, otherwise throws an exception.
+	**/
 	public function getRoot() {
 		throw "Not implemented";
 		return null;
 	}
 
+	/**
+		Returns the Bytes instance of the file under given `path`.
+		Should be overridden by inheriting class, otherwise throws an exception.
+	**/
+	@:dox(show)
 	function getBytes( path : String ) : haxe.io.Bytes {
 		throw "Not implemented";
 		return null;
 	}
 
+	/**
+		Returns whether file under given `path` exists.
+
+		Initially calls `getBytes()` and ideally should be overridden for optimization purposes.
+	**/
 	public function exists( path : String ) {
 		return getBytes(path) != null;
 	}
 
+	/**
+		Returns the BytesFileEntry instance for the file under given `path`.
+
+		Does not cache the file entries (causing a new entry instance returned on same path every time)
+		and ideally should be overridden for optimization purposes.
+
+		@throws `NotFound` if the file under given path does not exist.
+	**/
 	public function get( path : String ) {
 		var bytes = getBytes(path);
 		if( bytes == null ) throw "Resource not found '" + path + "'";
 		return new BytesFileEntry(path,bytes);
 	}
 
+	/**
+		Disposes of the BytesFileSystem.
+
+		Does nothing initially.
+	**/
 	public function dispose() {
 	}
 
+	/**
+		Should be overridden by inheriting class, otherwise throws an exception.
+	**/
 	public function dir( path : String ) : Array<FileEntry> {
 		throw "Not implemented";
 		return null;

--- a/hxd/fs/EmbedFileSystem.hx
+++ b/hxd/fs/EmbedFileSystem.hx
@@ -2,6 +2,9 @@ package hxd.fs;
 
 #if !macro
 
+/**
+	The file entry of the `EmbedFileSystem`. Cannot be created directly.
+**/
 @:allow(hxd.fs.EmbedFileSystem)
 @:access(hxd.fs.EmbedFileSystem)
 private class EmbedEntry extends FileEntry {
@@ -179,6 +182,16 @@ private class EmbedEntry extends FileEntry {
 
 #end
 
+/**
+	An embedded file system that stores the assets inside the compiled binary.
+
+	Can be initialized via `Res.initEmbed` or `EmbedFileSystem.create`.
+
+	Implementation uses `haxe.Resource` to store the data and due to that it is not advised to use Embed FS on production when targeting JS
+	as that would cause assets to be inserted as base-64 encoded variables, inflating the output JS file size immensely.
+
+	Due to its nature - cannot be instantiated directly.
+**/
 class EmbedFileSystem #if !macro implements FileSystem #end {
 
 	#if !macro
@@ -189,6 +202,9 @@ class EmbedFileSystem #if !macro implements FileSystem #end {
 		this.root = root;
 	}
 
+	/**
+		Returns the root FileEntry directory of the FileSystem.
+	**/
 	public function getRoot() : FileEntry {
 		return new EmbedEntry(this,"root",".",null);
 	}
@@ -237,6 +253,9 @@ class EmbedFileSystem #if !macro implements FileSystem #end {
 		return r != null && r != true;
 	}
 
+	/**
+		Checks whether the file under given `path` exists or not.
+	**/
 	public function exists( path : String ) {
 		#if flash
 		var f = open(path);
@@ -251,6 +270,11 @@ class EmbedFileSystem #if !macro implements FileSystem #end {
 		#end
 	}
 
+	/**
+		Returns the FileEntry instance under the given `path`.
+
+		@throws `NotFound` if the file under given path does not exist.
+	**/
 	public function get( path : String ) {
 		if( !exists(path) )
 			throw new NotFound(path);
@@ -271,6 +295,11 @@ class EmbedFileSystem #if !macro implements FileSystem #end {
 	}
 	#end
 
+	/**
+		Creates an embedded FileSystem with assets from given `basePath` and `options`.
+
+		@returns An instance of `EmbedFileSystem`.
+	**/
 	public static macro function create( ?basePath : String, ?options : hxd.res.EmbedOptions ) {
 		var f = new hxd.res.FileTree(basePath);
 		var data = f.embed(options);
@@ -282,9 +311,15 @@ class EmbedFileSystem #if !macro implements FileSystem #end {
 		return macro { $types; @:privateAccess new hxd.fs.EmbedFileSystem(haxe.Unserializer.run($v { sdata } )); };
 	}
 
+	/**
+		Does nothing.
+	**/
 	public function dispose() {
 	}
 
+	/**
+		Unsupported, will throw an error.
+	**/
 	public function dir( path : String ) : Array<FileEntry> {
 		throw "Not Supported";
 	}

--- a/hxd/fs/FileEntry.hx
+++ b/hxd/fs/FileEntry.hx
@@ -1,34 +1,142 @@
 package hxd.fs;
 
-class FileEntry {
+/**
+	The base class representing a single file in the FileSystem.
 
+	Should not be instantiated directly, as specific implementation lies on the FileSystem type used.
+**/
+class FileEntry {
+	/**
+		The name of the file.
+	**/
 	public var name(default, null) : String;
+	/**
+		The local path of the file.
+	**/
 	public var path(get, never) : String;
+	/**
+		The directory path the file is placed in.
+	**/
 	public var directory(get, never) : String;
+	/**
+		File extension of the file without the dot (i.e. `png`).
+	**/
 	public var extension(get, never) : String;
+	/**
+		The size of the file in bytes.
+	**/
 	public var size(get, never) : Int;
+	/**
+		Whether this entry is a directory.
+
+		Depending on FileSystem used, it may contain directory entries.
+		In that case they can be iterated over, but should not be accessed as files.
+	**/
 	public var isDirectory(get, never) : Bool;
+	/**
+		Whether this entry is loaded and its contents can be accessed. Otherwise `FileEntry.load` have to be called.
+
+		Depending on FileSystem, some files cannot be accessed immediately and have to be loaded first.
+		In that case `isAvailable` is `false` until file is loaded.
+	**/
 	public var isAvailable(get, never) : Bool;
 
-	// first four bytes of the file
+	/**
+		Returns the first four bytes of the file which usually is a file signature.
+	**/
 	public function getSign() : Int return 0;
 
+	/**
+		Returns the contents of the file as Bytes.
+	**/
 	public function getBytes() : haxe.io.Bytes return null;
 
+	/**
+		Returns the contents of the file as a String.
+	**/
 	public function getText() return getBytes().toString();
 
+	/**
+		Prepares file to be read from the start or moves the reading position to the beginning if its already opened.
+
+		This is an alternative way to read file data without storing its entirety in the RAM.
+		Note that depending on FileSystem used, they always load entire file into RAM, such as EmbedFileSystem or BytesFileSystem.
+		However for LocalFileSystem this is a preferred method of reading files when entirety of the file is not required in the RAM.
+
+		Required to be called before `FileEntry.skip`, `FileEntry.readByte` and `FileEntry.read` can be called.
+		`FileEntry.close` should be called after the file reading is complete.
+	**/
 	public function open() { }
+	/**
+		Moves the reading position of the file by `nbytes`.
+
+		File have to be opened first via `FileEntry.open`.
+	**/
 	public function skip( nbytes : Int ) { }
+	/**
+		Reads a single byte from the file.
+
+		File have to be opened first via `FileEntry.open`.
+	**/
 	public function readByte() : Int return 0;
+	/**
+		Reads the bytes from the file into the output Bytes.
+
+		File have to be opened first via `FileEntry.open`.
+
+		@param out The output Bytes instance file data is written into.
+		@param pos The position in `out` starting from which the data is written.
+		@param size The amount of bytes to read.
+	**/
 	public function read( out : haxe.io.Bytes, pos : Int, size : Int ) {}
+	/**
+		Closes the file previously opened file via `FileEntry.open`.
+	**/
 	public function close() {}
 
+	/**
+		Loads the file, preparing it to be accessed. `FileEntry.isAvailable` can be used to determine is file is loaded/ready to be accessed.
+
+		This is an asynchronous operation and delayed for at least one frame. Only exception is `LocalFileSystem` in macro context.
+		
+		@param onReady The callback that is invoked after the file is loaded.
+	**/
 	public function load( ?onReady : Void -> Void ) : Void { if( !isAvailable ) throw "load() not implemented"; else if( onReady != null ) onReady(); }
+	/**
+		Loads the file as platform-specific Bitmap. Will throw an exception for anything except JS and flash targets.
+		For FileSystem-independent bitmap loading use `hxd.res.Image` Resource.
+
+		This is an asynchronous operation and delayed for at least one frame.
+
+		@param onLoaded The callback that is invoked after the bitmap is loaded.
+	**/
 	public function loadBitmap( onLoaded : LoadedBitmap -> Void ) : Void { throw "loadBitmap() not implemented"; }
+	/**
+		Set the file change callback to the file. Only one callback can be set at a time and only works for `LocalFileSystem`.
+
+		@param onChanged The callback that is invoked when the file is changed. Pass `null` to stop monitoring the file for changes.
+	**/
 	public function watch( onChanged : Null<Void -> Void> ) { }
+	/**
+		Checks whether the file under the given name exists inside this file entry.
+		Usually a shortcut to `FileSystem.exists` this entry belongs to with combined path of this file and given name.
+
+		Can be used only for directory entries.
+	**/
 	public function exists( name : String ) : Bool return false;
+	/**
+		Returns the FileEntry instance of the file under given name inside this file entry.
+		Usually a shortcut to `FileSystem.get` this entry belongs to with combined path of this file and given name.
+
+		Can be used only for directory entries.
+	**/
 	public function get( name : String ) : FileEntry return null;
 
+	/**
+		Returns an iterator of FileEntries contained in this directory entry.
+
+		Can be used only for directory entries.
+	**/
 	public function iterator() : hxd.impl.ArrayIterator<FileEntry> return null;
 
 	function get_isAvailable() return true;

--- a/hxd/fs/FileInput.hx
+++ b/hxd/fs/FileInput.hx
@@ -1,14 +1,23 @@
 package hxd.fs;
 
+/**
+	An implementation of haxe Input with `FileEntry` as its base.
+**/
 class FileInput extends haxe.io.Input {
 
 	var f : FileEntry;
 
+	/**
+		Create a new FileInput instance with the given FileEntry `f`.
+	**/
 	public function new(f) {
 		this.f = f;
 		f.open();
 	}
 
+	/**
+		Skip the given `nbytes` bytes in the data stream.
+	**/
 	public function skip( nbytes : Int ) {
 		f.skip(nbytes);
 	}

--- a/hxd/fs/FileSystem.hx
+++ b/hxd/fs/FileSystem.hx
@@ -1,9 +1,39 @@
 package hxd.fs;
 
+/**
+	The base interface for the Resource system underlying file system.
+
+	@see `hxd.Res`
+**/
 interface FileSystem {
+	/**
+		Returns the root FileEntry directory of the FileSystem.
+
+		Not all file systems support `getRoot()`.
+	**/
 	public function getRoot() : FileEntry;
+	/**
+		Returns the FileEntry instance under the given `path`.
+
+		Depending on file system used, entry is not guaranteed to be available for reading right away and should be first loaded via `FileEntry.load`.
+
+		@throws `NotFound` if the file under given path does not exist.
+	**/
 	public function get( path : String ) : FileEntry;
+	/**
+		Checks whether the file under given `path` exists or not.
+	**/
 	public function exists( path : String ) : Bool;
+	/**
+		Disposes of the file system.
+
+		File systems are expected to free the allocated file data that was stored in RAM.
+	**/
 	public function dispose() : Void;
+	/**
+		Returns the FileEntry directory under the given `path`.
+
+		Not all file systems support `dir()`.
+	**/
 	public function dir( path : String ) : Array<FileEntry> ;
 }

--- a/hxd/fs/LoadedBitmap.hx
+++ b/hxd/fs/LoadedBitmap.hx
@@ -1,5 +1,6 @@
 package hxd.fs;
 
+@:dox(hide)
 #if flash
 typedef LoadedBitmapData = flash.display.BitmapData;
 #elseif js
@@ -8,12 +9,23 @@ typedef LoadedBitmapData = js.html.Image;
 typedef LoadedBitmapData = hxd.BitmapData;
 #end
 
+/**
+	The native image data wrapper. Produced by `FileEntry.loadBitmap`.
+
+	For JS underlying type is `js.html.Image`, otherwise it's `hxd.BitmapData`.
+**/
 abstract LoadedBitmap(LoadedBitmapData) {
 
+	/**
+		Create a new LoadedBitmap wrapper.
+	**/
 	public inline function new(data) {
 		this = data;
 	}
 
+	/**
+		Returns the BitmapData containing the pixels of this native image.
+	**/
 	public function toBitmap() : hxd.BitmapData {
 		#if flash
 		return hxd.BitmapData.fromNative(this);
@@ -26,6 +38,9 @@ abstract LoadedBitmap(LoadedBitmapData) {
 		#end
 	}
 
+	/**
+		Returns the underlying type of this image.
+	**/
 	public inline function toNative() : LoadedBitmapData {
 		return this;
 	}

--- a/hxd/fs/MultiFileSystem.hx
+++ b/hxd/fs/MultiFileSystem.hx
@@ -1,5 +1,8 @@
 package hxd.fs;
 
+/**
+	The `MultiFileSystem` file entry.
+**/
 private class MultiFileEntry extends FileEntry {
 
 	var fs : MultiFileSystem;
@@ -57,22 +60,46 @@ private class MultiFileEntry extends FileEntry {
 
 }
 
+/**
+	A container for multiple FileSystems that can be accessed as a singular FS.
+
+	The order of the file systems is important, as they are processed in first-come-first-serve manner, meaning that if file
+	exists in multiple instances, the first one that was found will be served.
+
+	Enables for usage of multiple different `FileSystem` instances to provide easy implementation of things like modding or 
+	partial asset embedding (by using `EmbedFileSystem` to store assets used while primary assets are loaded for another FS type).
+**/
 class MultiFileSystem implements FileSystem {
 
 	var cache : Map<String, MultiFileEntry>;
 	var root : MultiFileEntry;
+	/**
+		The list of FS instances used in the MultiFS.
+	**/
 	public var fs : Array<FileSystem>;
 
+	/**
+		Create a new MultiFileSystem instance.
+		@param fs The list of the FileSystem instances that are combined.
+	**/
 	public function new(fs) {
 		this.fs = fs;
 		cache = new Map();
 		root = new MultiFileEntry(this,[for( f in fs ) f.getRoot()]);
 	}
 
+	/**
+		Returns the root FileEntry directory of the FileSystem.
+	**/
 	public function getRoot() {
 		return root;
 	}
 
+	/**
+		Returns the FileEntry instance under the given `path`.
+
+		@throws `NotFound` if the file under given path does not exist.
+	**/
 	public function get( path : String ) : FileEntry {
 		var f = cache.get(path);
 		if( f != null )
@@ -94,6 +121,9 @@ class MultiFileSystem implements FileSystem {
 		return f;
 	}
 
+	/**
+		Checks whether the file under given `path` exists or not.
+	**/
 	public function exists( path : String ) : Bool {
 		for( f in fs )
 			if( f.exists(path) )
@@ -101,11 +131,17 @@ class MultiFileSystem implements FileSystem {
 		return false;
 	}
 
+	/**
+		Disposes of the file system and all underlying file system instances.
+	**/
 	public function dispose() {
 		for( f in fs )
 			f.dispose();
 	}
 
+	/**
+		Not supported and throws an error.
+	**/
 	public function dir( path : String ) : Array<FileEntry> {
 		throw "Not Supported";
 	}

--- a/hxd/fs/NotFound.hx
+++ b/hxd/fs/NotFound.hx
@@ -1,11 +1,20 @@
 package hxd.fs;
 
+/**
+	An exception thrown when the requested path was not found in the file system.
+**/
 class NotFound {
+	/**
+		The request path of the missing file.
+	**/
 	public var path : String;
+	/**
+		Create a new NotFound exception for the given `path`.
+	**/
 	public function new(path) {
 		this.path = path;
 	}
-	@:keep function toString() {
+	@:dox(hide) @:keep function toString() {
 		return "Resource file not found '" + path + "'";
 	}
 }


### PR DESCRIPTION
What the title says. Added documentation to `hxd.fs` package files.
It'll sit as a draft for a week or so, in case someone would want to fix my grammar or point at other issues.

Extra: Fixed some typos in private function methods of `FileConverter`

As usual, current up-to-date documentation available here: https://wb.yanrishatum.ru/heaps/api/
Coverage report: https://wb.yanrishatum.ru/heaps/api/coverage.html