### PR TITLE
Fix Haxe 4.2 threading issues

### DIFF
--- a/hxd/App.hx
+++ b/hxd/App.hx
@@ -36,6 +36,7 @@ class App implements h3d.IDrawable {
 	var isDisposed : Bool;
 
 	public function new() {
+		hxd.System.init();
 		var engine = h3d.Engine.getCurrent();
 		if( engine != null ) {
 			this.engine = engine;

--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -5,6 +5,13 @@ import sdl.Cursor;
 #elseif hldx
 import dx.Cursor;
 #end
+#if !usesys
+import haxe.MainLoop;
+#end
+#if ( target.threaded && (haxe_ver >= 4.2) )
+import sys.thread.Thread;
+import sys.thread.EventLoop;
+#end
 
 enum Platform {
 	IOS;
@@ -37,6 +44,10 @@ class System {
 
 	#if !usesys
 	static var sentinel : hl.UI.Sentinel;
+	#end
+	
+	#if ( target.threaded && (haxe_ver >= 4.2) )
+	static var mainThread : Thread;
 	#end
 
 	// -- HL
@@ -132,10 +143,24 @@ class System {
 		#if hxtelemetry
 		var hxt = new hxtelemetry.HxTelemetry();
 		#end
+		#if ( target.threaded && (haxe_ver >= 4.2) && heaps_unsafe_events)
+		var eventRecycle = [];
+		#end
 		while( true ) {
 			try {
 				hl.Api.setErrorHandler(reportError); // set exception trap
-				@:privateAccess haxe.MainLoop.tick();
+				#if ( target.threaded && (haxe_ver >= 4.2) )
+				// Due to how 4.2+ timers work, instead of MainLoop, thread events have to be updated.
+				// Unsafe events rely on internal implementation of EventLoop, but utilize the recycling feature
+				// which in turn provides better optimization.
+				#if heaps_unsafe_events
+				@:privateAccess mainThread.events.__progress(Sys.time(), eventRecycle);
+				#else
+				mainThread.events.progress();
+				#end
+				#else
+				@:privateAccess MainLoop.tick();
+				#end
 				if( !mainLoop() ) break;
 			} catch( e : Dynamic ) {
 				hl.Api.setErrorHandler(null);
@@ -396,16 +421,26 @@ class System {
 		#end
 	}
 
-	static function __init__() {
+	#if (hlsdl || hldx)
+	static var cursorLoop : MainEvent;
+	#end
+	public static function init() {
+		
+		#if ( target.threaded && (haxe_ver >= 4.2) )
+		mainThread = Thread.current();
+		#end
 		#if !usesys
-		hl.Api.setErrorHandler(function(e) reportError(e)); // initialization error
-		sentinel = new hl.UI.Sentinel(30, function() throw "Program timeout (infinite loop?)");
-		haxe.MainLoop.add(timeoutTick, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
+		if ( sentinel == null ) {
+			hl.Api.setErrorHandler(function(e) reportError(e)); // initialization error
+			sentinel = new hl.UI.Sentinel(30, function() throw "Program timeout (infinite loop?)");
+			MainLoop.add(timeoutTick, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
+		}
+		#end
+		#if (hlsdl || hldx)
+		if ( cursorLoop == null ) {
+			MainLoop.add(updateCursor, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
+		}
 		#end
 	}
-	
-	#if (hlsdl || hldx)
-	static var _ = haxe.MainLoop.add(updateCursor, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
-	#end
 
 }

--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -438,7 +438,8 @@ class System {
 		#end
 		#if (hlsdl || hldx)
 		if ( cursorLoop == null ) {
-			MainLoop.add(updateCursor, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
+			cursorLoop = MainLoop.add(updateCursor, -1);
+			#if (haxe_ver >= 4) cursorLoop.isBlocking = false #end;
 		}
 		#end
 	}

--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -424,16 +424,18 @@ class System {
 	#if (hlsdl || hldx)
 	static var cursorLoop : MainEvent;
 	#end
+	#if !usesys
+	static var timeoutLoop : MainEvent;
+	#end
 	public static function init() {
 		
 		#if ( target.threaded && (haxe_ver >= 4.2) )
 		mainThread = Thread.current();
 		#end
 		#if !usesys
-		if ( sentinel == null ) {
-			hl.Api.setErrorHandler(function(e) reportError(e)); // initialization error
-			sentinel = new hl.UI.Sentinel(30, function() throw "Program timeout (infinite loop?)");
-			MainLoop.add(timeoutTick, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
+		if ( timeoutLoop == null ) {
+			timeoutLoop = MainLoop.add(timeoutTick, -1);
+			#if (haxe_ver >= 4) timeoutLoop.isBlocking = false #end;
 		}
 		#end
 		#if (hlsdl || hldx)
@@ -441,6 +443,13 @@ class System {
 			cursorLoop = MainLoop.add(updateCursor, -1);
 			#if (haxe_ver >= 4) cursorLoop.isBlocking = false #end;
 		}
+		#end
+	}
+
+	static function __init__() {
+		#if !usesys
+		hl.Api.setErrorHandler(function(e) reportError(e)); // initialization error
+		sentinel = new hl.UI.Sentinel(30, function() throw "Program timeout (infinite loop?)");
 		#end
 	}
 

--- a/hxd/System.hx
+++ b/hxd/System.hx
@@ -53,6 +53,12 @@ class System {
 	}
 
 	/**
+		Platform-specific initialization, such as HL sentinel or cursor update on HL/JS.
+	**/
+	public static function init( ) : Void {
+	}
+
+	/**
 		Sets currently shown cursor.
 		This method is designated to be used by custom `hxd.System.setCursor`.
 		Calling it outside of automated Interactive cursor update system leads to undefined behavior, and not advised.

--- a/hxd/System.js.hx
+++ b/hxd/System.js.hx
@@ -144,8 +144,11 @@ class System {
 	static function get_allowTimeout() return false;
 	static function set_allowTimeout(b) return false;
 
-	static function __init__() : Void {
-		haxe.MainLoop.add(updateCursor, -1);
+	static var cursorLoop : haxe.MainLoop.MainEvent;
+	public static function init() : Void {
+		if ( cursorLoop == null ) {
+			cursorLoop = haxe.MainLoop.add(updateCursor, -1);
+		}
 	}
 
 }


### PR DESCRIPTION
Should fix #922 for good.

* I extracted `__init__` into a separate `init()` method to avoid prioritization bugs from compiler (init code of MainLoop/Timer was not executed before init code of Heaps that relies on it) and call it on App creation.
* Instead of calling `MainLoop.tick`, `Thread.events.progress()` is called, resolving the issue.
* There's an optional `heaps_unsafe_events` flag that enables usage of `__progress`. It's more optimal, as it recycles the event array, but I disabled it by default because it relies on internal implementation of `EventLoop`.
* Because `runMainLoop` is executed from the `EventLoop.loop` of the thread, it will have 2 more events scheduled to run right after it: The Driver initialization event and MainLoop tick, but because `runMainLoop` normally exists via `Sys.exit(0)` it should not be a problem.