### PR TITLE
Fix for 4.2.1

### DIFF
--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -419,7 +419,6 @@ class System {
 		#if !usesys
 		hl.Api.setErrorHandler(function(e) reportError(e)); // initialization error
 		sentinel = new hl.UI.Sentinel(30, function() throw "Program timeout (infinite loop?)");
-		haxe.MainLoop.add(timeoutTick, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
 		#end
 		#if ( target.threaded && (haxe_ver >= 4.2) )
 		mainThread = sys.thread.Thread.current();
@@ -427,7 +426,10 @@ class System {
 	}
 	
 	#if (hlsdl || hldx)
-	static var _ = haxe.MainLoop.add(updateCursor, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
+	static var _ = {
+		haxe.MainLoop.add(timeoutTick, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
+		haxe.MainLoop.add(updateCursor, -1) #if (haxe_ver >= 4) .isBlocking = false #end;
+	}
 	#end
 
 }


### PR DESCRIPTION
Hey ;)

Mutex at `haxe/MainLoop.hx:112` is still null because it is static and it is not yet initialized when `__init__` magic tries to get access to it.  So, moving `timeoutTick` loop to the static initializer in the same way as `updateCursor` loop was moved in a previous 4.2 fixes will do the trick.

Thank you.
