### PR TITLE
Timer default smoothing

### DIFF
--- a/hxd/Timer.hx
+++ b/hxd/Timer.hx
@@ -25,7 +25,7 @@ class Timer {
 		the results for tmod/dt/fps over frames using the formula   dt = lerp(dt, elapsedTime, smoothFactor)
 		Default : 0 on HashLink, 0.95 on other platforms
 	**/
-	public static var smoothFactor = 0.95;
+	public static var smoothFactor = #if hl 0. #else 0.95 #end;
 
 	/**
 		The last timestamp in which update() function was called.


### PR DESCRIPTION
The doc specified that default Timer smoothing on Hashlink is 0.0, while it wasn't. 
**This PR fixes the 0.0 value on Hashlink target, while keeping 0.95 anywhere else**.