### PR TITLE
Fixed default Timer smoothing to comply with its description

### DIFF
--- a/hxd/Timer.hx
+++ b/hxd/Timer.hx
@@ -25,7 +25,7 @@ class Timer {
 		the results for tmod/dt/fps over frames using the formula   dt = lerp(dt, elapsedTime, smoothFactor)
 		Default : 0 on HashLink, 0.95 on other platforms
 	**/
-	public static var smoothFactor = 0.95;
+	public static var smoothFactor = #if hl 0. #else 0.95 #end;
 
 	/**
 		The last timestamp in which update() function was called.


### PR DESCRIPTION
This PR fixes the default `smoothing` value of `hxd.Timer`, which wasn't complying its own description: 

- 0.0 on Hashlink target
- 0.95 anywhere else