### PR TITLE
Fix crash on atlas loading with anim starting at 1

### DIFF
--- a/hxd/res/Atlas.hx
+++ b/hxd/res/Atlas.hx
@@ -128,11 +128,11 @@ class Atlas extends Resource {
 				}
 				tl[index] = { t : t, width : origW, height : origH };
 			}
-
-			// remove first element if index started at 1 instead of 0
-			for( tl in contents )
-				if( tl.length > 1 && tl[0] == null ) tl.shift();
 		}
+
+		// remove first element if index started at 1 instead of 0
+		for( tl in contents )
+			if( tl.length > 1 && tl[0] == null ) tl.shift();
 		return contents;
 	}
 


### PR DESCRIPTION
When starting an animation at 1, the first element in the contents map's array will be null. If removed at the end of the page parsing loop, when adding subsequent element, the index offset won't be reduced. Thus resulting in the insertion of null in the array. With the example atlas below it would give this : `[{...}, null, {...}]`.
Moving the array shift at the end of the parsing solve this issue.

```
cards.png
size: 1024,1024
format: RGBA8888
filter: Nearest,Nearest
repeat: none
manon_commons
  rotate: false
  xy: 0, 0
  size: 678, 1024
  orig: 678, 1024
  offset: 0, 0
  index: 1

cards2.png
size: 1024,1024
format: RGBA8888
filter: Nearest,Nearest
repeat: none
manon_commons
  rotate: false
  xy: 0, 0
  size: 678, 1024
  orig: 678, 1024
  offset: 0, 0
  index: 2
```