### PR TITLE
Transition class not instantiating or running animations in order

### DIFF
--- a/h3d/anim/SmoothTransition.hx
+++ b/h3d/anim/SmoothTransition.hx
@@ -145,4 +145,11 @@ class SmoothTransition extends Transition {
 		return rt;
 	}
 
+	override function clone(?a : Animation) : Animation {
+		if( a == null )
+			a = new SmoothTransition(anim1, anim2, speed);
+		super.clone(a);
+		var a : SmoothTransition = cast a;
+		return a;
+	}
 }

--- a/h3d/anim/Transition.hx
+++ b/h3d/anim/Transition.hx
@@ -35,7 +35,11 @@ class Transition extends Animation {
 			a = new Transition(this.name.split("(")[0], anim1, anim2);
 		super.clone(a);
 		a.anim1 = anim1.clone();
+		a.anim1.initInstance();
+		a.anim1.loop = false;
 		a.anim2 = anim2.clone();
+		a.anim2.initInstance();
+		a.anim2.loop = false;
 		return a;
 	}
 
@@ -59,8 +63,10 @@ class Transition extends Animation {
 		while( tmp > 0 )
 			tmp = anim1.update(tmp);
 		var tmp = st;
-		while( tmp > 0 )
-			tmp = anim2.update(tmp);
+		if (anim1.frame == anim1.frameCount) {
+			while( tmp > 0)
+				tmp = anim2.update(tmp);
+		}
 		return rt;
 	}
 


### PR DESCRIPTION
Fixes issues:
- `Transition.clone()` doesn't instantiate anim1 and anim2, which fails when `Transition.update()` triggers `anim1.update()` and `anim2.update()`
- `Transition.update()` doesn't handle the issue where both `anim1` and `anim2` start on frame 0. In that case, it updates them both simultaneously, instead of waiting for `anim1` to finish.
- `SmoothTransition` doesn't have its own `clone` method and falls back on `Transition` clone method.