### PR TITLE
Use highp for GLSL vertex shader

### DIFF
--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -653,11 +653,16 @@ class GlslOut {
 		buf = new StringBuf();
 		exprValues = [];
 
-		decl("precision mediump float;");
-
 		if( s.funs.length != 1 ) throw "assert";
 		var f = s.funs[0];
 		isVertex = f.kind == Vertex;
+		
+		if (isVertex) {
+			decl("precision highp float;");
+		} else {
+			decl("precision mediump float;");
+		}
+
 		initVars(s);
 
 		var tmp = buf;


### PR DESCRIPTION
_First of all, thank you for this engine, it's been nice to work with it! :)_

Now, I've been experiencing weird distortion issues on some mobile phones when moving not too far away from the origin (~2000px). Examples:

Actual vs Expected:
<img src="https://user-images.githubusercontent.com/1260622/121312131-5c91a380-c905-11eb-969d-901f970a37e9.jpg" width="300" height="533"><img src="https://user-images.githubusercontent.com/1260622/121312183-6a472900-c905-11eb-97e8-785007ef2331.jpg" width="300" height="533">

Also a video:

https://user-images.githubusercontent.com/1260622/121310872-1be55a80-c904-11eb-8a10-c4b3a1bc7ea0.mp4

I've constructed a minimal example that you might be able to reproduce on your phone if you are lucky: [website](https://zommerfelds.github.io/heaps-cordova), [source](https://github.com/zommerfelds/heaps-cordova/blob/main/src/App.hx). The white lines start to have unstable width and the top octopus starts to wiggle ([bad recording example](https://user-images.githubusercontent.com/1260622/121325390-da5bac00-c911-11eb-9ebd-2b14b0833a99.mp4)).

This only happens on some devices, but a significant amount of them. I've also noticed this in other games such as Deepnight games.

I tracked this down to be floating point precision issues in the Base2D shader: https://github.com/HeapsIO/heaps/blob/8f7f439116692013b4d9182acb633ba56283dabf/hxsl/GlslOut.hx#L656
`mediump` can have as low as 10 bits of digits, which is very imprecise for vertex and camera calculations. These are the possible solutions I can see:

## Option A (workaround): force developers to use screen coordinates

I did this for my game. Basically we need to stop using a hierarchy of objects and camera, and set screen coordinates directly. This means manually translating your scene around the origin. If using `h2d.Graphics` or `h2d.SpriteBatch` then they should have coordinates 0/0 and the drawn objects/BatchElems should contain screen coordinates. This can quickly get annoying and I'm tempted to use my fork of Heaps for now.

## Option B (highp): use higher floating point precision

This is what this PR does. According to the OpenGL spec, setting the precision should have no effect on non-ES platform (desktop). `highp` is always supported by the vertex shader so I'm setting it only there.

People at Defold have done the same, check out their analysis: https://github.com/defold/defold/issues/3128

Here's the same video with the fix: 

https://user-images.githubusercontent.com/1260622/121324445-075b8f00-c911-11eb-97aa-1942e9dbe6a8.mp4

Of course we could put this behind a flag, but I think this should have no visible impact for only the vertex shader, so IMO default highp for vertex shader is good.

## Option C (CPU): convert coordinates on CPU rather than on shader

By computing absolute values on the CPU before sending them to the shader we avoid the precision loss. Of course this comes with the disadvantage of more CPU work. I've tried a [prototype of this for SpriteBatch](https://github.com/HeapsIO/heaps/compare/master...zommerfelds:spritebatch-coord) and it worked in most cases but it didn't work using h2d.Camera because of the precision loss in viewport calculation. One way to fix this is to add an option in the Base2D shader to prevent any kind of coordinate conversion on the GPU. B is probably the better option though :)

What do you think?