### PR TITLE
Fix release click/key outside of scene

### DIFF
--- a/hxd/Key.hx
+++ b/hxd/Key.hx
@@ -225,8 +225,10 @@ class Key {
 			keyPressed[e.keyCode] = -getFrame();
 		case EPush:
 			if( e.button < 5 ) keyPressed[e.button] = getFrame();
-		case ERelease , EReleaseOutside:
+		case ERelease:
 			if( e.button < 5 ) keyPressed[e.button] = -getFrame();
+		case EReleaseOutside:
+			keyPressed = [];
 		case EWheel:
 			keyPressed[e.wheelDelta > 0 ? MOUSE_WHEEL_DOWN : MOUSE_WHEEL_UP] = getFrame();
 		default:

--- a/hxd/Key.hx
+++ b/hxd/Key.hx
@@ -225,7 +225,7 @@ class Key {
 			keyPressed[e.keyCode] = -getFrame();
 		case EPush:
 			if( e.button < 5 ) keyPressed[e.button] = getFrame();
-		case ERelease:
+		case ERelease , EReleaseOutside:
 			if( e.button < 5 ) keyPressed[e.button] = -getFrame();
 		case EWheel:
 			keyPressed[e.wheelDelta > 0 ? MOUSE_WHEEL_DOWN : MOUSE_WHEEL_UP] = getFrame();

--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -85,6 +85,7 @@ class Window {
 		
 		element.addEventListener("mousedown", onMouseDown);
 		element.addEventListener("mouseup", onMouseUp);
+		element.addEventListener("mouseleave", onMouseLeave);
 		element.addEventListener("wheel", onMouseWheel);
 		element.addEventListener("touchstart", onTouchStart);
 		element.addEventListener("touchmove", onTouchMove);
@@ -274,6 +275,32 @@ class Window {
 				onMouseMove(e);
 		}
 		var ev = new Event(ERelease, mouseX, mouseY);
+		ev.button = switch( e.button ) {
+			case 1: 2;
+			case 2: 1;
+			case x: x;
+		};
+		event(ev);
+	}
+
+	function onMouseLeave(e:js.html.MouseEvent) {
+		if (e.altKey) {
+			var altEv = new Event(EKeyUp, mouseX, mouseY);
+			altEv.keyCode = js.html.KeyboardEvent.DOM_VK_ALT;
+			event(altEv);
+		}
+		if (e.ctrlKey) {
+			var ctrlEv = new Event(EKeyUp, mouseX, mouseY);
+			ctrlEv.keyCode = js.html.KeyboardEvent.DOM_VK_CONTROL;
+			event(ctrlEv);
+		}
+		if (e.shiftKey) {
+			var shiftEv = new Event(EKeyUp, mouseX, mouseY);
+			shiftEv.keyCode = js.html.KeyboardEvent.DOM_VK_SHIFT;
+			event(shiftEv);
+		}
+		
+		var ev = new Event(EReleaseOutside, mouseX, mouseY);
 		ev.button = switch( e.button ) {
 			case 1: 2;
 			case 2: 1;

--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -284,22 +284,6 @@ class Window {
 	}
 
 	function onMouseLeave(e:js.html.MouseEvent) {
-		if (e.altKey) {
-			var altEv = new Event(EKeyUp, mouseX, mouseY);
-			altEv.keyCode = js.html.KeyboardEvent.DOM_VK_ALT;
-			event(altEv);
-		}
-		if (e.ctrlKey) {
-			var ctrlEv = new Event(EKeyUp, mouseX, mouseY);
-			ctrlEv.keyCode = js.html.KeyboardEvent.DOM_VK_CONTROL;
-			event(ctrlEv);
-		}
-		if (e.shiftKey) {
-			var shiftEv = new Event(EKeyUp, mouseX, mouseY);
-			shiftEv.keyCode = js.html.KeyboardEvent.DOM_VK_SHIFT;
-			event(shiftEv);
-		}
-		
 		var ev = new Event(EReleaseOutside, mouseX, mouseY);
 		ev.button = switch( e.button ) {
 			case 1: 2;


### PR DESCRIPTION
Fix a bug where if the click or a keysuch as alt, ctrl or shift was hit in a 3d scene then released outside of it, the release event was not captured.
Causing to stay locked on a specific edit mode even though the key is released.