### PR TITLE
Add `showDebug` property to 3D Interactives

### DIFF
--- a/h3d/col/Bounds.hx
+++ b/h3d/col/Bounds.hx
@@ -401,7 +401,14 @@ class Bounds implements Collider {
 		return b;
 	}
 
-	#if (hxbit && !macro)
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var prim = new h3d.prim.Cube(xMax - xMin, yMax - yMin, zMax - zMin);
+		prim.translate(xMin, yMin, zMin);
+		prim.addNormals();
+		return new h3d.scene.Mesh(prim);
+	}
+	#if hxbit
 	function customSerialize( ctx : hxbit.Serializer ) {
 		ctx.addFloat(xMin);
 		ctx.addFloat(xMax);
@@ -418,6 +425,7 @@ class Bounds implements Collider {
 		zMin = ctx.getFloat();
 		zMax = ctx.getFloat();
 	}
+	#end
 	#end
 
 }

--- a/h3d/col/Capsule.hx
+++ b/h3d/col/Capsule.hx
@@ -105,7 +105,39 @@ class Capsule implements Collider {
 		return "Capsule{" + a + "," + b + "," + hxd.Math.fmt(r) + "}";
 	}
 
-	#if (hxbit && !macro)
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var obj = new h3d.scene.Object();
+
+		var segW = 12;
+		var segH = 6;
+
+		var dir = a.sub(b);
+		var full = a.add(b);
+		var dist = a.distance(b);
+		var midPoint = new Point(full.x / 2, full.y / 2, full.z / 2);
+
+		var prim = new h3d.prim.Sphere(r, segW, segH, 0.5);
+		prim.translate(0, 0, dist / 2);
+		prim.addNormals();
+		var spherea = new h3d.scene.Mesh(prim);
+		var sphereb = spherea.clone();
+		spherea.rotate(0, Math.PI / 2, 0);
+		obj.addChild(spherea);
+		sphereb.rotate(0, -1 * Math.PI / 2, 0);
+		obj.addChild(sphereb);
+
+		var cyl = new h3d.prim.Cylinder(segW, r, dist, true);
+		cyl.addNormals();
+		var cylMesh = new h3d.scene.Mesh(cyl);
+		cylMesh.rotate(0, Math.PI / 2, 0);
+		obj.addChild(cylMesh);
+
+		obj.setDirection(dir.toVector());
+		obj.setPosition(midPoint.x, midPoint.y, midPoint.z);
+		return obj;
+	}
+	#if hxbit
 	function customSerialize( ctx : hxbit.Serializer ) {
 		ctx.addFloat(a.x);
 		ctx.addFloat(a.y);
@@ -120,6 +152,7 @@ class Capsule implements Collider {
 		b = new Point(ctx.getFloat(), ctx.getFloat(), ctx.getFloat());
 		r = ctx.getFloat();
 	}
+	#end
 	#end
 
 }

--- a/h3d/col/Collider.hx
+++ b/h3d/col/Collider.hx
@@ -10,6 +10,10 @@ interface Collider extends hxd.impl.Serializable.StructSerializable {
 	public function contains( p : Point ) : Bool;
 	public function inFrustum( f : Frustum, ?localMatrix : h3d.Matrix ) : Bool;
 	public function inSphere( s : Sphere ) : Bool;
+
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object;
+	#end
 }
 
 
@@ -41,11 +45,25 @@ class OptimizedCollider implements hxd.impl.Serializable implements Collider {
 		return a.inSphere(s) && b.inSphere(s);
 	}
 
-	#if (hxbit && !macro)
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var bobj = b.makeDebugObj();
+		var aobj = a.makeDebugObj();
+		if( aobj == null && bobj == null )
+			return null;
+		var ret = new h3d.scene.Object();
+		if( aobj != null )
+			ret.addChild(aobj);
+		if( bobj != null )
+			ret.addChild(bobj);
+		return ret;
+	}
+	#if hxbit
 	function customSerialize(ctx:hxbit.Serializer) {
 	}
 	function customUnserialize(ctx:hxbit.Serializer) {
 	}
+	#end
 	#end
 
 }
@@ -91,7 +109,20 @@ class GroupCollider implements Collider {
 		return false;
 	}
 
-	#if (hxbit && !macro && heaps_enable_serialize)
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var ret : h3d.scene.Object = null;
+		for( c in colliders ) {
+			var toAdd = c.makeDebugObj();
+			if( toAdd == null )
+				continue;
+			if( ret == null )
+				ret = new h3d.scene.Object();
+			ret.addChild(toAdd);
+		}
+		return ret;
+	}
+	#if (hxbit && heaps_enable_serialize)
 
 	function customSerialize(ctx:hxbit.Serializer) {
 		ctx.addInt(colliders.length);
@@ -103,6 +134,7 @@ class GroupCollider implements Collider {
 		colliders = [for( i in 0...ctx.getInt() ) ctx.getStruct()];
 	}
 
+	#end
 	#end
 
 

--- a/h3d/col/HeightMap.hx
+++ b/h3d/col/HeightMap.hx
@@ -85,4 +85,9 @@ class HeightMap implements Collider {
 		}
 	}
 
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		return null;
+	}
+	#end
 }

--- a/h3d/col/ObjectCollider.hx
+++ b/h3d/col/ObjectCollider.hx
@@ -64,6 +64,17 @@ class ObjectCollider implements Collider implements hxd.impl.Serializable {
 		return res;
 	}
 
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var ret = collider.makeDebugObj();
+		if( ret != null ) {
+			ret.ignoreParentTransform = true;
+			ret.follow = obj;
+		}
+		return ret;
+	}
+	#end
+
 	#if hxbit
 	function customSerialize( ctx : hxbit.Serializer ) {
 	}

--- a/h3d/col/Polygon.hx
+++ b/h3d/col/Polygon.hx
@@ -144,12 +144,23 @@ class TriPlane implements Collider {
 		return [new Point(p0x, p0y, p0z), new Point(d1x + p0x, d1y + p0y, d1z + p0z), new Point(d2x + p0x, d2y + p0y, d2z + p0z)];
 	}
 
-	#if (hxbit && !macro)
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var p0 = new Point(p0x, p0y, p0z);
+		var d1 = new Point(d1x, d1y, d1z);
+		var d2 = new Point(d2x, d2y, d2z);
+		var points : Array<Point> = [ p0, d1.add(p0), d2.add(p0) ];
+		var prim = new h3d.prim.Polygon(points);
+		prim.addNormals();
+		return new h3d.scene.Mesh(prim);
+	}
+	#if hxbit
 	function customSerialize( ctx : hxbit.Serializer ) {
 		throw "Cannot serialize "+this;
 	}
 	function customUnserialize( ctx : hxbit.Serializer ) {
 	}
+	#end
 	#end
 
 }
@@ -190,7 +201,6 @@ class Polygon implements Collider {
 
 	public function clone() : h3d.col.Polygon {
 		var clone = new h3d.col.Polygon();
-		clone.triPlanes = new TriPlane();
 		clone.triPlanes = triPlanes.clone();
 		return clone;
 	}
@@ -262,12 +272,32 @@ class Polygon implements Collider {
 		return false;
 	}
 
-	#if (hxbit && !macro)
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var points : Array<Point> = [];
+		var idx = new hxd.IndexBuffer();
+
+		var t = triPlanes;
+		while( t != null ) {
+			var p0 = new Point(t.p0x, t.p0y, t.p0z);
+			var d1 = new Point(t.d1x, t.d1y, t.d1z);
+			var d2 = new Point(t.d2x, t.d2y, t.d2z);
+			points.push(p0);
+			points.push(d1.add(p0));
+			points.push(d2.add(p0));
+			t = t.next;
+		}
+		var prim = new h3d.prim.Polygon(points);
+		prim.addNormals();
+		return new h3d.scene.Mesh(prim);
+	}
+	#if hxbit
 	function customSerialize( ctx : hxbit.Serializer ) {
 		throw "Cannot serialize "+this;
 	}
 	function customUnserialize( ctx : hxbit.Serializer ) {
 	}
+	#end
 	#end
 
 	public static function fromPolygon2D( p : h2d.col.Polygon, z = 0. ) {

--- a/h3d/col/PolygonBuffer.hx
+++ b/h3d/col/PolygonBuffer.hx
@@ -92,7 +92,25 @@ class PolygonBuffer implements Collider {
 		return best;
 	}
 
-	#if (hxbit && !macro)
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var points = new Array<Point>();
+		var idx = new hxd.IndexBuffer();
+		var i = startIndex;
+		for( t in 0...triCount ) {
+			idx.push(indexes[i++]);
+			idx.push(indexes[i++]);
+			idx.push(indexes[i++]);
+		}
+		i = 0;
+		while( i < buffer.length ) {
+			points.push(new Point(buffer[i++], buffer[i++], buffer[i++]));
+		}
+		var prim = new h3d.prim.Polygon(points, idx);
+		prim.addNormals();
+		return new h3d.scene.Mesh(prim);
+	}
+	#if hxbit
 	function customSerialize( ctx : hxbit.Serializer ) {
 		if( source == null )
 			throw "Cannot serialize " + this;
@@ -115,6 +133,7 @@ class PolygonBuffer implements Collider {
 		var prim = @:privateAccess lib.makePrimitive(gindex);
 		@:privateAccess prim.initCollider(this);
 	}
+	#end
 	#end
 
 }

--- a/h3d/col/SkinCollider.hx
+++ b/h3d/col/SkinCollider.hx
@@ -91,13 +91,18 @@ class SkinCollider implements hxd.impl.Serializable implements Collider {
 		}
 	}
 
-	#if (hxbit && !macro)
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		return null;
+	}
+	#if hxbit
 	function customSerialize( ctx : hxbit.Serializer ) {
 	}
 	function customUnserialize( ctx : hxbit.Serializer ) {
 		this.transform = new PolygonBuffer();
 		this.transform.setData(col.buffer.copy(), col.indexes, col.startIndex, col.triCount);
 	}
+	#end
 	#end
 
 }

--- a/h3d/col/Sphere.hx
+++ b/h3d/col/Sphere.hx
@@ -86,7 +86,14 @@ class Sphere implements Collider {
 		return "Sphere{" + getCenter()+","+ hxd.Math.fmt(r) + "}";
 	}
 
-	#if (hxbit && !macro)
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var prim = new h3d.prim.Sphere(r, 20, 15);
+		prim.translate(x, y, z);
+		prim.addNormals();
+		return new h3d.scene.Mesh(prim);
+	}
+	#if hxbit
 	function customSerialize( ctx : hxbit.Serializer ) {
 		ctx.addFloat(x);
 		ctx.addFloat(y);
@@ -99,6 +106,7 @@ class Sphere implements Collider {
 		z = ctx.getFloat();
 		r = ctx.getFloat();
 	}
+	#end
 	#end
 
 }

--- a/h3d/col/TransformCollider.hx
+++ b/h3d/col/TransformCollider.hx
@@ -72,6 +72,15 @@ class TransformCollider implements Collider {
 		return res;
 	}
 
+	#if !macro
+	public function makeDebugObj() : h3d.scene.Object {
+		var obj = collider.makeDebugObj();
+		obj.ignoreParentTransform = true;
+		obj.defaultTransform = mat;
+		return obj;
+	}
+	#end
+
 	public static function make( mat : h3d.Matrix, col ) {
 		if( mat.isIdentityEpsilon(1e-10) )
 			return col;

--- a/h3d/prim/Sphere.hx
+++ b/h3d/prim/Sphere.hx
@@ -7,28 +7,30 @@ class Sphere extends Polygon {
 	@:s var segsH : Int;
 	@:s var segsW : Int;
 
-	public function new( ray = 1., segsW = 8, segsH = 6 ) {
+	// Use 1 for a full sphere, 0.5 for a half sphere
+	@:s var portion : Float;
+
+	public function new( ray = 1., segsW = 8, segsH = 6, portion = 1. ) {
 		this.ray = ray;
 		this.segsH = segsH;
 		this.segsW = segsW;
+		this.portion = portion;
 
 		var dp = Math.PI * 2 / segsW;
 		var pts = [], idx = new hxd.IndexBuffer();
-		var dx = 1, dy = segsW + 1;
 		for( y in 0...segsH+1 ) {
-			var t = (y / segsH) * Math.PI;
+			var t = (y / segsH) * Math.PI * portion;
 			var st = Math.sin(t);
 			var pz = Math.cos(t);
 			var p = 0.;
 			for( x in 0...segsW+1 ) {
 				var px = st * Math.cos(p);
 				var py = st * Math.sin(p);
-				var i = pts.length;
 				pts.push(new Point(px * ray, py * ray, pz * ray));
 				p += dp;
 			}
 		}
-		for( y in 0...segsH )
+		for( y in 0...segsH ) {
 			for( x in 0...segsW ) {
 				inline function vertice(x, y) return x + y * (segsW + 1);
 				var v1 = vertice(x + 1, y);
@@ -40,12 +42,13 @@ class Sphere extends Polygon {
 					idx.push(v2);
 					idx.push(v4);
 				}
-				if( y != segsH - 1 ) {
+				if( y != segsH - 1 || portion != 1. ) {
 					idx.push(v2);
 					idx.push(v3);
 					idx.push(v4);
 				}
 			}
+		}
 
 		super(pts, idx);
 	}

--- a/h3d/scene/Interactive.hx
+++ b/h3d/scene/Interactive.hx
@@ -2,6 +2,9 @@ package h3d.scene;
 
 class Interactive extends Object implements hxd.SceneEvents.Interactive {
 
+	var debugObj : Object;
+	public var showDebug(default, set) : Bool = false;
+
 	@:s public var shape : h3d.col.Collider;
 
 	/**
@@ -40,6 +43,38 @@ class Interactive extends Object implements hxd.SceneEvents.Interactive {
 		super(parent);
 		this.shape = shape;
 		cursor = Button;
+	}
+
+	public function set_showDebug(val) {
+		if( !val ) {
+			if( debugObj != null )
+				debugObj.remove();
+			debugObj = null;
+			return false;
+		}
+		if( debugObj != null )
+			return true;
+		debugObj = shape.makeDebugObj();
+		if( debugObj != null ) {
+			setupDebugMaterial(debugObj);
+
+			debugObj.ignoreParentTransform = true;
+			this.addChild(debugObj);
+		}
+		return debugObj != null;
+	}
+
+	public static dynamic function setupDebugMaterial(debugObj: Object) {
+		var materials = debugObj.getMaterials();
+		for( m in materials ) {
+			var engine = h3d.Engine.getCurrent();
+			if( engine.driver.hasFeature(Wireframe) )
+				m.mainPass.wireframe = true;
+			m.castShadows = false;
+			m.receiveShadows = false;
+			// m.blendMode = Alpha;
+			// m.mainPass.depth(false, Always);
+		}
 	}
 
 	override function onAdd() {


### PR DESCRIPTION
This property displays an object that shows the collider (wireframe by default)
Also updated samples/Interactive to use this feature

When you activate this, the new sample looks like this:
![image](https://user-images.githubusercontent.com/22801009/123404700-6411a780-d5a9-11eb-9a77-ec56eebc45f9.png)

If you need the debug objects' materials to be different (eg. not wireframe), override `Interactive.setupDebugMaterial` which is a static dynamic function.