### PR TITLE
Fix h3d.Scene.Skin.getBoundsRec not scaling correctly

### DIFF
--- a/h3d/scene/Skin.hx
+++ b/h3d/scene/Skin.hx
@@ -105,15 +105,17 @@ class Skin extends MultiMaterial {
 		syncJoints();
 		if( skinData.vertexWeights == null )
 			cast(primitive, h3d.prim.HMDModel).loadSkin(skinData);
+		var absScale = getAbsPos().getScale();
+		var scale = Math.max(Math.max(absScale.x, absScale.y), absScale.z);
 		for( j in skinData.allJoints ) {
 			if( j.offsetRay < 0 ) continue;
 			var m = currentPalette[j.bindIndex];
 			var pt = j.offsets.getMin();
 			pt.transform(m);
-			b.addSpherePos(pt.x, pt.y, pt.z, j.offsetRay);
+			b.addSpherePos(pt.x, pt.y, pt.z, j.offsetRay * scale);
 			var pt = j.offsets.getMax();
 			pt.transform(m);
-			b.addSpherePos(pt.x, pt.y, pt.z, j.offsetRay);
+			b.addSpherePos(pt.x, pt.y, pt.z, j.offsetRay * scale);
 		}
 		return b;
 	}


### PR DESCRIPTION
Note that this does not support non uniform scaling

This fixes issues with interactives on scaled skins not triggering when the camera is too close to the object.

Fixes at least part of #596 