### PR TITLE
fixup! Fix h3d.Scene.Skin.getBoundsRec not scaling correctly (#974)

### DIFF
--- a/h3d/scene/Skin.hx
+++ b/h3d/scene/Skin.hx
@@ -94,6 +94,7 @@ class Skin extends MultiMaterial {
 		return s;
 	}
 
+	static var tmpVec = new h3d.Vector();
 	override function getBoundsRec( b : h3d.col.Bounds ) {
 		// ignore primitive bounds !
 		var old = primitive;
@@ -105,7 +106,7 @@ class Skin extends MultiMaterial {
 		syncJoints();
 		if( skinData.vertexWeights == null )
 			cast(primitive, h3d.prim.HMDModel).loadSkin(skinData);
-		var absScale = getAbsPos().getScale();
+		var absScale = getAbsPos().getScale(tmpVec);
 		var scale = Math.max(Math.max(absScale.x, absScale.y), absScale.z);
 		for( j in skinData.allJoints ) {
 			if( j.offsetRay < 0 ) continue;


### PR DESCRIPTION
Optimizes #974 to have one less alloc per `getBoundsRec()` call