### PR TITLE
fix bug in World sample (WorldMesh had incorrect parameters)

### DIFF
--- a/samples/World.hx
+++ b/samples/World.hx
@@ -23,7 +23,7 @@ class World extends hxd.App {
 
 	override function init() {
 
-		world = new WorldMesh(16, s3d);
+		world = new WorldMesh(64, 128, s3d);
 		var t = world.loadModel(hxd.Res.tree);
 		var r = world.loadModel(hxd.Res.rock);
 


### PR DESCRIPTION
I pulled the repo to work with the 'World' sample.  After following the instructions to generate and build it, it seemed to be calling out an invalid call to WorldMesh().
I cross-referenced the online example and found the correct arguments, updated locally and it fixed it.
Hope this helps others.
I'm a newbie to pull requests. Please advise if I'm doing something wrong.