### PR TITLE
Add 3D collision sample

### DIFF
--- a/samples/Collision3d.hx
+++ b/samples/Collision3d.hx
@@ -1,0 +1,94 @@
+class Collision3d extends hxd.App {
+  static inline var ENEMY_COLOR = 0xcc0000;
+  static inline var PLAYER_COLOR = 0x0000cc;
+  static inline var COLLIDED_COLOR = 0xcc00cc;
+  static inline var PLAYER_SPEED = 10;
+
+  var enemy : h3d.scene.Mesh;
+  var player : h3d.scene.Mesh;
+  var text : h2d.Text;
+
+  override function init() {
+    // checkered ground
+    var worldSize = 16;
+    var halfWorldSize = Std.int(worldSize / 2);
+    var tileSize = 2;
+    var tiles = Std.int(worldSize / tileSize);
+    var plane = new h3d.prim.Cube(tileSize, tileSize, 0);
+    plane.addNormals();
+    plane.addUVs();
+
+    for (x in 0...tiles) {
+      for (y in 0...tiles) {
+        var mesh = new h3d.scene.Mesh(plane, s3d);
+        var yOddEven = x % 2 == 0 ? 1 : 0;
+        var color = y % 2 == yOddEven ? 0x408020 : 0x204010;
+        mesh.x = x * tileSize - halfWorldSize;
+        mesh.y = y * tileSize - halfWorldSize;
+        mesh.material.texture = h3d.mat.Texture.fromColor(color);
+      }
+    }
+
+    // primitive cube
+    var cube = new h3d.prim.Cube(3, 3, 3);
+    cube.translate(-0.5, -0.5, -0.5);
+    cube.addNormals();
+    cube.addUVs();
+
+    // enemy mesh
+    enemy = new h3d.scene.Mesh(cube, s3d);
+    enemy.x = -5;
+    enemy.y = 1;
+    enemy.z = 3;
+    enemy.material.color.setColor(ENEMY_COLOR);
+
+    // player mesh
+    player = new h3d.scene.Mesh(cube, s3d);
+    player.z = 1.5;
+    player.material.color.setColor(PLAYER_COLOR);
+
+    // camera
+    s3d.camera.target.set(0, 0, 0);
+    s3d.camera.pos.set(30, 30, 25);
+    new h3d.scene.CameraController(s3d).loadFromCamera();
+
+    // directional light
+    new h3d.scene.fwd.DirLight(new h3d.Vector(0.3, -0.4, -0.9), s3d);
+    cast(s3d.lightSystem, h3d.scene.fwd.LightSystem).ambientLight.setColor(0x909090);
+
+    // text instructions
+    text = new h2d.Text(hxd.res.DefaultFont.get(), s2d);
+    text.x = 15;
+    text.y = 15;
+  }
+
+  override function update(dt: Float) {
+    // simple x or y movement, can't move diagonally (x and y) or vertically (z)
+    var dx = 0;
+    var dy = 0;
+
+    if (hxd.Key.isDown(hxd.Key.A)) {
+      dx = -1;
+    } else if (hxd.Key.isDown(hxd.Key.D)) {
+      dx = 1;
+    } else if (hxd.Key.isDown(hxd.Key.W)) {
+      dy = -1;
+    } else if (hxd.Key.isDown(hxd.Key.S)) {
+      dy = 1;
+    }
+
+    player.x += dt * dx * PLAYER_SPEED;
+    player.y += dt * dy * PLAYER_SPEED;
+
+    // check for player collision with enemy
+    var collided = player.getBounds().collide(enemy.getBounds());
+
+    player.material.color.setColor(collided ? COLLIDED_COLOR : PLAYER_COLOR);
+
+    text.text = 'wasd move cube\nplayer x: ${player.x}\nplayer y: ${player.y}\nplayer collided: ${collided}';
+  }
+
+  static function main() {
+    new Collision3d();
+  }
+}


### PR DESCRIPTION
New to heaps, and the samples are great, but couldn't find anything on 3D collision detection, so I made this to help myself, and hopefully it helps others. 

I ended up figuring out from the docs and code that [Bounds collide](https://heaps.io/api/h3d/col/Bounds.html#collide) from [Object getBounds](https://heaps.io/api/h3d/scene/Object.html#getBounds) will check for collision, but not sure if that's a correct approach.

```
var collided = player.getBounds().collide(enemy.getBounds());
```

Seems to work with fine primitives, like `Cube`, but unsure if it will work for FBX models, other primitives etc, as I assume `Bounds` is like a bounding box. That's good enough for what I'm doing, so at least I thought I'd share to the community as I'm sure others are curious how to do basic 3D box collision detection if they haven't discovered it already.

If this isn't the appropriate or best pattern to check for 3D collision, please let me know. I realize making and finding examples takes time, and I appreciate yours on all your hard work on heaps. I tried digging into some listed 3D source examples, like [Cherry-jam](https://github.com/Yanrishatum/cherry-jam/) listed on [heaps.io](https://heaps.io/documentation/full-game-samples.html), and tried scourging github for a few days and couldn't find any 3D collision detection. I'm sure there's some code out there but hard to find. If there's a more correct pattern, I'm happy to learn and will change the sample.

If there's a process for contributing and PR's, couldn't find it, but would be happy to adhere to it. Lastly, looks like the samples are not synced to [heaps.io](https://heaps.io/samples/) automatically, maybe it's a manual process, or a script to do so? Might be worth to add the newer ones, happy to help if I can.