### PR TITLE
Fix null pointer exception on stopCapture

### DIFF
--- a/h2d/Interactive.hx
+++ b/h2d/Interactive.hx
@@ -253,6 +253,7 @@ class Interactive extends Drawable implements hxd.SceneEvents.Interactive {
 		Stops current input event capture.
 	**/
 	public function stopCapture() {
+		if ( scene == null ) return;
 		scene.stopCapture();
 	}
 


### PR DESCRIPTION
It is possible to destroy a scene while performing a drag. I have code like this:

```
flow.interactive.startCapture((e2) -> {
  switch (e2.kind) {
    case EMove:
      ...
    case _:
      flow.interactive.stopCapture();
  }
});
```

My callback was being called when then scene was deleted and causing an exception inside stopCapture(). This change fixes it for me.