### PR TITLE
Allow usage of 2D Bounds as a collider

### DIFF
--- a/h2d/col/Bounds.hx
+++ b/h2d/col/Bounds.hx
@@ -7,7 +7,7 @@ import hxd.Math;
 	@see `Object.getBounds`
 	@see `Object.getSize`
 **/
-class Bounds {
+class Bounds implements Collider {
 
 	/** X-axis left-most bounding box point. **/
 	public var xMin : Float;


### PR DESCRIPTION
What's the title says. Bounds already satisfies Collider interface requirements.

Example use-case is using bounding box of another object as a shape for Interactive with `obj.getBounds(interactive, interBounds)`