### PR TITLE
JS: Use ResizeObserver when possible

### DIFF
--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -95,7 +95,15 @@ class Window {
 		element.addEventListener("blur", onFocus.bind(false));
 		element.addEventListener("focus", onFocus.bind(true));
 
-		js.Browser.window.addEventListener("resize", checkResize);
+		if ((js.Browser.window:Dynamic).ResizeObserver != null) {
+			// Modern solution for canvas resize monitoring, supported in most browsers, but not Haxe API.
+			var observer = js.Syntax.construct("ResizeObserver", function(e) {
+				checkResize();
+			});
+			observer.observe(canvas);
+		} else {
+			js.Browser.window.addEventListener("resize", checkResize);
+		}
 
 		canvas.oncontextmenu = function(e){
 			e.stopPropagation();


### PR DESCRIPTION
This should fix issues that #967 introduced for some people, causing canvas not being properly resized at startup.

Solution uses JS API that is not present in Haxe 4.2, i.e. `ResizeObserver` class, however it is supported by [pretty much everything](https://caniuse.com/?search=ResizeObserver), and it provides far more consistent resize callback specifically for canvas as we don't really need to know if window was resized - only canvas itself.

Update: It seems that it didn't completely fix the issue, do not merge yet, I need to investigate.