### PR TITLE
Fix web target causing haptic feedback when long pressing

### DIFF
--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -97,11 +97,13 @@ class Window {
 
 		js.Browser.window.addEventListener("resize", checkResize);
 
-		canvas.oncontextmenu = function(e){
+		canvas.addEventListener("contextmenu", function(e){
 			e.stopPropagation();
-			e.preventDefault();
+			if (e.button == 2) {
+				e.preventDefault();
+			}
 			return false;
-		};
+		});
 		if( globalEvents ) {
 			// make first mousedown on canvas trigger event
 			canvas.addEventListener("mousedown", function(e) {


### PR DESCRIPTION
The contextmenu listener would cause short vibrations on mobile devices when long pressing.

It happened because the contextmenu listener was defaultPrevented. Checking if the right
mouse button was clicked fixes the issue.