### PR TITLE
Restore hxd.fs.FileEntry.getSign

### DIFF
--- a/hxd/fs/FileEntry.hx
+++ b/hxd/fs/FileEntry.hx
@@ -36,6 +36,14 @@ class FileEntry {
 			throw new haxe.io.Eof();
 	}
 
+	/**
+		Read first 4 bytes of the file.
+	**/
+	public function getSign() : Int {
+		var bytes = fetchBytes(0, 4);
+		return bytes.get(0) | (bytes.get(1) << 8) | (bytes.get(2) << 16) | (bytes.get(3) << 24);
+	}
+
 	public function getText() return getBytes().toString();
 	public function open() return @:privateAccess new FileInput(this);
 


### PR DESCRIPTION
Fix breaking API change from ea6012ab891a703c42b6d9b4a7bafa76a9766703

That method is actually being used, for example to distinct unprocessed .gif and processed .gif -> .png spritesheet with frame metadata chunk:
https://github.com/Yanrishatum/heeps/blob/56153497b9f8b6928731065229be0540cbd55810/cherry/res/GifImage.hx#L30-L32

I know it's not on purpose, but pls stop breaking file system ;)