### PR TITLE
Fixed std.is warning

### DIFF
--- a/h3d/mat/PbrMaterial.hx
+++ b/h3d/mat/PbrMaterial.hx
@@ -198,7 +198,7 @@ class PbrMaterial extends Material {
 		mainPass.enableLights = true;
 
 		// Backward compatibility
-		if(Std.is((props:Dynamic).culling, Bool))
+		if(Std.isOfType((props:Dynamic).culling, Bool))
 			props.culling = (props:Dynamic).culling ? Back : None;
 		#if editor
 		if( (props:Dynamic).colorMask == null ) props.colorMask = 15;


### PR DESCRIPTION
In PBRMaterial.hx, changed Std.is to Std.isOfType to get rid of the warning