### PR TITLE
"sample" not allowed in JS shaders

### DIFF
--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -4,7 +4,7 @@ import hxsl.Ast;
 class GlslOut {
 
 	static var KWD_LIST = [
-		"input", "output", "discard", "sample",
+		"input", "output", "discard", #if js "sample", #end
 		"dvec2", "dvec3", "dvec4", "hvec2", "hvec3", "hvec4", "fvec2", "fvec3", "fvec4",
 		"int", "float", "bool", "long", "short", "double", "half", "fixed", "unsigned", "superp",
 		"lowp", "mediump", "highp", "precision", "invariant", "discard",

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -4,7 +4,7 @@ import hxsl.Ast;
 class GlslOut {
 
 	static var KWD_LIST = [
-		"input", "output", "discard",
+		"input", "output", "discard", "sample",
 		"dvec2", "dvec3", "dvec4", "hvec2", "hvec3", "hvec4", "fvec2", "fvec3", "fvec4",
 		"int", "float", "bool", "long", "short", "double", "half", "fixed", "unsigned", "superp",
 		"lowp", "mediump", "highp", "precision", "invariant", "discard",


### PR DESCRIPTION
The keyword `sample` causes a runtime error on shader creation on JS target ("sample: Illegal use of a reserved word"). The below edit to `h3d.shader.SinusDeform` will cause the error, and errors also occur with `ScreenShader`. The same shaders work fine on HL.

```haxe
// h3d.shader.SinusDeform

function fragment() {
	var sample = sin(calculatedUV.y * frequency + time * speed) * amplitude;
	calculatedUV.x += sample;
}
```

This change adds "sample" to the reserved keyword list.

Tested in Edge browser on heaps 96c2e91a072788e91aea7e3b5d4b5c82cbe57f3b