### PR TITLE
Add precision for sampler2DArray

### DIFF
--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -659,8 +659,10 @@ class GlslOut {
 		
 		if (isVertex) {
 			decl("precision highp float;");
+			decl("precision mediump sampler2DArray;");
 		} else {
 			decl("precision mediump float;");
+			decl("precision mediump sampler2DArray;");
 		}
 
 		initVars(s);


### PR DESCRIPTION
Fixes issue: https://github.com/HeapsIO/heaps/issues/1035 
Shader compilation on Chrome will throw an error when using `texture.size()` function in HXSL with any `sampler2DArray` (i.e. fragmentTextures[]). Oddly the error is only thrown when a Chrome debugger is attached. I could not find any sources as to what Chrome does differently with regards to GL error checking.