### PR TITLE
Fix Blender fbx model scaling (again)

### DIFF
--- a/hxd/fmt/fbx/BaseLibrary.hx
+++ b/hxd/fmt/fbx/BaseLibrary.hx
@@ -265,8 +265,10 @@ class BaseLibrary {
 			case "LastSaved|ApplicationName": app = p.props[4].toString();
 			default:
 			}
-		if( app.indexOf("Blender") >= 0 && unitScale == originScale )
-			scaleFactor = unitScale / 100; // Adjust blender output scaling
+		if( app.indexOf("Blender") >= 0 && unitScale == originScale ) {
+			if ( unitScale == 0 ) scaleFactor = 1; // 0.9999999776482582 scale turning into 0
+			else scaleFactor = unitScale / 100; // Adjust blender output scaling
+		}
 
 		if( scaleFactor == 1 && geometryScaleFactor == 1 )
 			return;


### PR DESCRIPTION
Newer Blender versions output scale factor as `0.9999999776482582`, that turns into 0 by Heaps (why it's even floored?), causing `scaleFactor` to become 0 and do lots of NaN issues.