### PR TITLE
h2d.SpriteBatch: Removed +0.1 offsets when !hasRotationScale

### DIFF
--- a/h2d/SpriteBatch.hx
+++ b/h2d/SpriteBatch.hx
@@ -400,7 +400,7 @@ class SpriteBatch extends Drawable {
 				tmp[pos++] = e.g;
 				tmp[pos++] = e.b;
 				tmp[pos++] = e.a;
-				tmp[pos++] = sx + t.width + 0.1;
+				tmp[pos++] = sx + t.width;
 				tmp[pos++] = sy;
 				tmp[pos++] = t.u2;
 				tmp[pos++] = t.v;
@@ -409,15 +409,15 @@ class SpriteBatch extends Drawable {
 				tmp[pos++] = e.b;
 				tmp[pos++] = e.a;
 				tmp[pos++] = sx;
-				tmp[pos++] = sy + t.height + 0.1;
+				tmp[pos++] = sy + t.height;
 				tmp[pos++] = t.u;
 				tmp[pos++] = t.v2;
 				tmp[pos++] = e.r;
 				tmp[pos++] = e.g;
 				tmp[pos++] = e.b;
 				tmp[pos++] = e.a;
-				tmp[pos++] = sx + t.width + 0.1;
-				tmp[pos++] = sy + t.height + 0.1;
+				tmp[pos++] = sx + t.width;
+				tmp[pos++] = sy + t.height;
 				tmp[pos++] = t.u2;
 				tmp[pos++] = t.v2;
 				tmp[pos++] = e.r;


### PR DESCRIPTION
Here is what it does when rendering an element : (Cross cursor is at (6,6))
![image](https://user-images.githubusercontent.com/102484529/168419179-7e2c74dc-46a8-4266-aa11-ae9a5391c08e.png)

