### PR TITLE
Fixed EOut/Eover window events for JS target

### DIFF
--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -85,6 +85,7 @@ class Window {
 
 		element.addEventListener("mousedown", onMouseDown);
 		element.addEventListener("mouseup", onMouseUp);
+		element.addEventListener("mouseenter", onMouseEnter);
 		element.addEventListener("mouseleave", onMouseLeave);
 		element.addEventListener("wheel", onMouseWheel);
 		element.addEventListener("touchstart", onTouchStart);
@@ -297,13 +298,13 @@ class Window {
 		event(ev);
 	}
 
+	function onMouseEnter(e:js.html.MouseEvent) {
+		var ev = new Event(EOver, mouseX, mouseY);
+		event(ev);
+	}
+
 	function onMouseLeave(e:js.html.MouseEvent) {
-		var ev = new Event(EReleaseOutside, mouseX, mouseY);
-		ev.button = switch( e.button ) {
-			case 1: 2;
-			case 2: 1;
-			case x: x;
-		};
+		var ev = new Event(EOut, mouseX, mouseY);
 		event(ev);
 	}
 


### PR DESCRIPTION
Issue: current `onMouseLeave()` method fires an `EReleaseOutside` event to targets, which is inconsistent:

1. the button value is always zero, no matter if the user "left" the canvas with a mouse button pressed or not.
2. the expected event should be `EOut` here.

Fix: 
1. replaced the previously not working `EReleaseOutside` with `EOut`
2. added an `onMouseEnter` callback as well to support `EOver`
