### PR TITLE
Functions to allow extension config using --macro

### DIFF
--- a/hxd/res/Config.hx
+++ b/hxd/res/Config.hx
@@ -31,6 +31,10 @@ class Config {
 		#end
 	];
 
+	public static function addExtension( extension, className) {
+		extensions.set(extension, className);
+	}
+
 	/**
 		File extensions ignored by the resource scan
 	**/

--- a/hxd/res/Config.hx
+++ b/hxd/res/Config.hx
@@ -68,6 +68,13 @@ class Config {
 		"css" => "less",
 	];
 
+	public static function addPairedExtension( main, shadow) {
+		if (pairedExtensions.exists(main)) 
+			pairedExtensions.set(main, pairedExtensions.get(main) + "," + shadow);
+		else 
+			pairedExtensions.set(main, shadow);
+	}
+
 	static function defined( name : String ) {
 		return haxe.macro.Context.defined(name);
 	}


### PR DESCRIPTION
Added two functions that allow you to use --macro to add either a pairedExension or map an extension to a class.

These functions seemed necessary as use the --macro on the variable threw a compiler error.  These functions are safer anyway.