### PR TITLE
Fixed: PBR Directional, Spot and Point lights broken in Javascript target due to null vallues in shaders.

### DIFF
--- a/h3d/scene/pbr/Light.hx
+++ b/h3d/scene/pbr/Light.hx
@@ -7,7 +7,7 @@ class Light extends h3d.scene.Light {
 	public var power : Float = 1.;
 	public var shadows : h3d.pass.Shadows;
 	public var isMainLight = false;
-	public var occlusionFactor : Float;
+	public var occlusionFactor : Float = 0.;
 	public var enableForward : Bool = true;
 
 	function new(shader,?parent) {

--- a/h3d/scene/pbr/PointLight.hx
+++ b/h3d/scene/pbr/PointLight.hx
@@ -3,7 +3,7 @@ package h3d.scene.pbr;
 class PointLight extends Light {
 
 	var pbr : h3d.shader.pbr.Light.PointLight;
-	public var size : Float;
+	public var size : Float = 0.;
 	public var zNear : Float = 0.02;
 	/**
 		Alias for uniform scale.

--- a/h3d/scene/pbr/SpotLight.hx
+++ b/h3d/scene/pbr/SpotLight.hx
@@ -6,7 +6,7 @@ class SpotLight extends Light {
 
 	public var range(get,set) : Float;
 	public var angle(default,set) : Float;
-	public var fallOff : Float;
+	public var fallOff : Float = 0.;
 	public var cookie : h3d.mat.Texture;
 	var lightProj : h3d.Camera;
 


### PR DESCRIPTION
Currenty in the JS examples all PBR lights are borkne, showing hard shadows without any color from lights.

The reason was that the WebGL shader for the light pass would pass the **occlusionFactor** member of `h3d.scene.pbr.Light` as **null**, as part of the pbrLightColor vector in the shader. 

For example a red light would show up as (1, 1, 1, null), instead of (1, 0, 0, 0), the fourth parameter being **pbrOcclusionFactor**. Particularly in the Directional lLight fragment shader mix sentence (pixelColor.rgb += direct * shadow * mix(1, occlusion, pbrOcclusionFactor););

Here is the Result for the types of values this would shoot out on certain vairables in Spector.js (notice the null value)
![imagen](https://user-images.githubusercontent.com/44873757/185697038-5972ca2f-576c-484d-895e-6a3b56ff1583.png)

This made Webgl not know what to do and mark the whole color result in the shader as 0, e.g. black.

The values in question are :
   * occlusionFactor: Affct all light, but particularly Directional Light
   * falloff: From Spot light, affect the fallof of the spotlight, without this the spot will lawsy be hard-edged
   * size: The point size of the Point lights. Its not that visible but it can generate artifacts ad the edges and make a distance check always fail.

Defining ther value at the start as .0 fixes the null invalidation and srt its to 0 as defualt.

Here is the result before the change
![imagen](https://user-images.githubusercontent.com/44873757/185697117-9cfae522-a756-419f-8826-856ce543ad4d.png)
And here is the change
![imagen](https://user-images.githubusercontent.com/44873757/185697214-c57c3b02-e202-4ede-b873-5d7a455e3098.png)

Here is the result after the change for falloff  lights
Before:
![imagen](https://user-images.githubusercontent.com/44873757/185713306-eec7340f-2599-4d90-9cb5-16491be3556f.png)
After:
![imagen](https://user-images.githubusercontent.com/44873757/185713228-4305e0e6-c837-4aa7-9837-b4f3fd436d79.png)

And point lights:
Before:
![imagen](https://user-images.githubusercontent.com/44873757/185713420-e30ecd95-dc03-4407-ad9e-4db6f9d6b29c.png)
After (adjusting bias in the sample for the point light):
![imagen](https://user-images.githubusercontent.com/44873757/185713363-81e6c171-2025-49a7-9406-a54f2e896bd3.png)

Hopefully being a small PR, its easy to review and merge.

Thsi PR fixes issue #1075 