### PR TITLE
Fixed: 8-bit WAV files playing with glitches due to incorrect sample rate calculation

### DIFF
--- a/hxd/snd/webaudio/Driver.hx
+++ b/hxd/snd/webaudio/Driver.hx
@@ -130,7 +130,7 @@ class Driver implements hxd.snd.Driver {
 				if (channelCount == 1) {
 					var chn = buffer.inst.getChannelData(0);
 					for ( i in 0...sampleCount ) {
-						chn[i] = ui8[i] / 0xff;
+						chn[i] = (ui8[i] - 0x80) / 0x80;
 					}
 				} else {
 					var left = buffer.inst.getChannelData(0);
@@ -138,8 +138,8 @@ class Driver implements hxd.snd.Driver {
 					// TODO: 3+ channels
 					var r = 0;
 					for ( i in 0...sampleCount ) {
-						left[i] = ui8[r] / 0xff;
-						right[i] = ui8[r+1] / 0xff;
+						left[i] = (ui8[r] - 0x80) / 0x80;
+						right[i] = (ui8[r+1] - 0x80) / 0x80;
 						r += channelCount;
 					}
 				}


### PR DESCRIPTION
The WAV file specification mentions that 8-bit samples are stored as unsigned int, whereas bigger bit depths (16-bit and above) are stored in signed ints. 
    * See here: https://www.lightlink.com/tjweber/StripWav/Canon.html for details.

And in JS, the webaudio AudioBuffer specification requieres to change the sample rate to a 32-bit float value in the [-1, 1] range.
    * See here: https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer

The webaudio Driver.hx file assumes that the forma is in the [-128, 128] range and divides by 255. This works in 16-bit files, but because of the specification, its actually stored in [0, 255], with 128 being the midpoint, dividng by 255 will cause glitches in the sound as its being calculated incorrectly. 

Changing the way the sample is calculated for JS by substracting and dividing by 128 will set the range correctly and avoid sound glitches.

This PR fixes the #1067 issue and its reproduction project that containt two WAV files, one in 8-bit and the other in 16-bit, and on whcih the 8-bit WAV presetn glitches in its sound.