### PR TITLE
Implement mouseClip and mouseMode API

### DIFF
--- a/h3d/scene/CameraController.hx
+++ b/h3d/scene/CameraController.hx
@@ -156,14 +156,23 @@ class CameraController extends h3d.scene.Object {
 			else
 				zoom(e.wheelDelta);
 		case EPush:
-			@:privateAccess scene.events.startCapture(onEvent, function() pushing = -1, e.touchId);
+			@:privateAccess scene.events.startCapture(onEvent, function() {
+				pushing = -1;
+				var wnd = hxd.Window.getInstance();
+				wnd.mouseMode = Absolute;
+				wnd.setCursorPos(Std.int(pushStartX), Std.int(pushStartY));
+			}, e.touchId);
 			pushing = e.button;
 			pushTime = haxe.Timer.stamp();
 			pushStartX = pushX = e.relX;
 			pushStartY = pushY = e.relY;
+			hxd.Window.getInstance().mouseMode = AbsoluteUnbound;
 		case ERelease, EReleaseOutside:
 			if( pushing == e.button ) {
 				pushing = -1;
+				var wnd = hxd.Window.getInstance();
+				wnd.mouseMode = Absolute;
+				wnd.setCursorPos(Std.int(pushStartX), Std.int(pushStartY));
 				@:privateAccess scene.events.stopCapture();
 				if( e.kind == ERelease && haxe.Timer.stamp() - pushTime < 0.2 && hxd.Math.distance(e.relX - pushStartX,e.relY - pushStartY) < 5 )
 					onClick(e);

--- a/h3d/scene/CameraController.hx
+++ b/h3d/scene/CameraController.hx
@@ -166,7 +166,7 @@ class CameraController extends h3d.scene.Object {
 			pushTime = haxe.Timer.stamp();
 			pushStartX = pushX = e.relX;
 			pushStartY = pushY = e.relY;
-			hxd.Window.getInstance().mouseMode = AbsoluteUnbound;
+			hxd.Window.getInstance().mouseMode = AbsoluteUnbound(true);
 		case ERelease, EReleaseOutside:
 			if( pushing == e.button ) {
 				pushing = -1;

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -154,9 +154,12 @@ class Window {
 		for( f in resizeEvents ) f();
 	}
 
-	public function setCursorPos( x : Int, y : Int ) : Void {
+	public function setCursorPos( x : Int, y : Int, emitEvent: Bool = false ) : Void {
 		#if hldx
 		window.setCursorPosition(x, y);
+		curMouseX = x;
+		curMouseY = y;
+		if (emitEvent) event(new hxd.Event(EMove, x, y));
 		#else
 		throw "Not implemented";
 		#end

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -163,6 +163,8 @@ class Window {
 	public function setCursorPos( x : Int, y : Int, emitEvent: Bool = false ) : Void {
 		#if hldx
 		if (mouseMode == Absolute) window.setCursorPosition(x, y);
+		#elseif hlsdl
+		if (mouseMode == Absolute) window.warpMouse(x, y);
 		#else
 		throw "Not implemented";
 		#end
@@ -205,6 +207,8 @@ class Window {
 	function get_mouseClip() : Bool {
 		#if hldx
 		return _mouseClip;
+		#elseif hlsdl
+		return window.grab;
 		#else
 		return false;
 		#end
@@ -214,6 +218,8 @@ class Window {
 		#if hldx
 		window.clipCursor(v);
 		return _mouseClip = v;
+		#elseif hlsdl
+		return window.grab = v;
 		#else
 		if( v ) throw "Not implemented";
 		return false;
@@ -225,6 +231,15 @@ class Window {
 
 		var forced = onMouseModeChange(mouseMode, v);
 		if (forced != null) v = forced;
+
+		#if hldx
+		window.setRelativeMouseMode(v != Absolute);
+		return mouseMode = v;
+		#elseif hlsdl
+		sdl.Sdl.setRelativeMouseMode(v != Absolute);
+		#else
+		if ( v != Absolute ) throw "Not implemented";
+		#end
 
 		if ( v == Absolute ) {
 			switch ( mouseMode ) {
@@ -238,6 +253,8 @@ class Window {
 					}
 					#if hldx
 					window.setCursorPosition(curMouseX, curMouseY);
+					#elseif hlsdl
+					window.warpMouse(curMouseX, curMouseY);
 					#end
 				default:
 			}
@@ -246,13 +263,7 @@ class Window {
 		startMouseX = curMouseX;
 		startMouseY = curMouseY;
 		
-		#if hldx
-		window.setRelativeMouseMode(v != Absolute);
 		return mouseMode = v;
-		#else
-		if ( v != Absolute ) throw "Not implemented";
-		return Absolute;
-		#end
 	}
 
 	#if (hldx||hlsdl)

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -40,7 +40,7 @@ class Window {
 	public var height(get, never) : Int;
 	public var mouseX(get, never) : Int;
 	public var mouseY(get, never) : Int;
-	@:deprecated("Use mouseMode = AbsoluteUnbound")
+	@:deprecated("Use mouseMode = AbsoluteUnbound(true)")
 	public var mouseLock(get, set) : Bool;
 	public var mouseClip(get, set) : Bool;
 	public var mouseMode(default, set): MouseMode = Absolute;
@@ -160,7 +160,7 @@ class Window {
 		for( f in resizeEvents ) f();
 	}
 
-	public function setCursorPos( x : Int, y : Int, emitEvent: Bool = false ) : Void {
+	public function setCursorPos( x : Int, y : Int, emitEvent : Bool = false ) : Void {
 		#if hldx
 		if (mouseMode == Absolute) window.setCursorPosition(x, y);
 		#elseif hlsdl

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -42,7 +42,15 @@ class Window {
 	public var mouseY(get, never) : Int;
 	@:deprecated("Use mouseMode = AbsoluteUnbound(true)")
 	public var mouseLock(get, set) : Bool;
+	/**
+		If set, will restrain the mouse cursor within the window boundaries.
+	**/
 	public var mouseClip(get, set) : Bool;
+	/**
+		Set the mouse movement input handling mode.
+
+		@see `hxd.impl.MouseMode` for more details on each mode.
+	**/
 	public var mouseMode(default, set): MouseMode = Absolute;
 	public var monitor : Null<Int> = null;
 	public var framerate : Null<Int> = null;

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -229,8 +229,16 @@ class Window {
 		if ( v == Absolute ) {
 			switch ( mouseMode ) {
 				case Relative(_, restorePos) | AbsoluteUnbound(restorePos) | AbsoluteWrap(restorePos):
-					if ( restorePos ) setCursorPos(startMouseX, startMouseY);
-					else setCursorPos(hxd.Math.iclamp(curMouseX, 0, width), hxd.Math.iclamp(curMouseY, 0, height));
+					if ( restorePos ) {
+						curMouseX = startMouseX;
+						curMouseY = startMouseY;
+					} else {
+						curMouseX = hxd.Math.iclamp(curMouseX, 0, width);
+						curMouseY = hxd.Math.iclamp(curMouseY, 0, height);
+					}
+					#if hldx
+					window.setCursorPosition(curMouseX, curMouseY);
+					#end
 				default:
 			}
 		}
@@ -346,6 +354,7 @@ class Window {
 						ev.propagate = false;
 						ev.relX = curMouseX;
 						ev.relY = curMouseY;
+						eh = ev;
 					}
 				case AbsoluteUnbound(_):
 					#if (hldx || hlsdl)

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -243,7 +243,7 @@ class Window {
 
 		if ( v == Absolute ) {
 			switch ( mouseMode ) {
-				case Relative(_, restorePos) | AbsoluteUnbound(restorePos) | AbsoluteWrap(restorePos):
+				case Relative(_, restorePos) | AbsoluteUnbound(restorePos):
 					if ( restorePos ) {
 						curMouseX = startMouseX;
 						curMouseY = startMouseY;
@@ -375,19 +375,6 @@ class Window {
 					curMouseX += e.mouseX - curMouseX;
 					curMouseY += e.mouseY - curMouseY;
 					#end
-					eh = new Event(EMove, curMouseX, curMouseY);
-				case AbsoluteWrap(_):
-					#if (hldx || hlsdl)
-					curMouseX += e.mouseXRel;
-					curMouseY += e.mouseYRel;
-					#else
-					curMouseX += e.mouseX - curMouseX;
-					curMouseY += e.mouseY - curMouseY;
-					#end
-					if (curMouseX < 0) curMouseX = width + (curMouseX % width);
-					else if (curMouseX >= width) curMouseX %= width;
-					if (curMouseY < 0) curMouseY = height + (curMouseY % height);
-					else if (curMouseY >= height) curMouseY %= height;
 					eh = new Event(EMove, curMouseX, curMouseY);
 			}
 		case MouseWheel:

--- a/hxd/Window.hx
+++ b/hxd/Window.hx
@@ -42,6 +42,17 @@ class Window {
 		return true;
 	}
 
+	/**
+		An event called when `mouseMode` is changed.
+
+		Note that changing from `Relative(callbackA)` to `Relative(callbackB)` would also cause this event as any other parameter changes.
+
+		@returns Force-override of the mouse mode that will be used as an active mode or null.
+	**/
+	public dynamic function onMouseModeChange( from : MouseMode, to : MouseMode ) : Null<MouseMode> {
+		return null;
+	}
+
 	public function event( e : hxd.Event ) : Void {
 		for( et in eventTargets )
 			et(e);
@@ -113,11 +124,11 @@ class Window {
 	}
 
 	function get_mouseLock() : Bool {
-		return mouseMode == AbsoluteUnbound;
+		return switch (mouseMode) { case AbsoluteUnbound(_): true; default: false; };
 	}
 
-	function set_mouseLock( v : Bool ) : Bool {
-		return set_mouseMode(v ? AbsoluteUnbound : Absolute) == AbsoluteUnbound;
+	function set_mouseLock(v:Bool) : Bool {
+		return set_mouseMode(v ? AbsoluteUnbound(true) : Absolute).equals(AbsoluteUnbound(true));
 	}
 
 	function get_mouseClip() : Bool {

--- a/hxd/Window.hx
+++ b/hxd/Window.hx
@@ -17,7 +17,7 @@ class Window {
 	public var height(get, never) : Int;
 	public var mouseX(get, never) : Int;
 	public var mouseY(get, never) : Int;
-	@:deprecated("Use mouseMode = AbsoluteUnbound")
+	@:deprecated("Use mouseMode = AbsoluteUnbound(true)")
 	public var mouseLock(get, set) : Bool;
 	/**
 		If set, will restrain the mouse cursor within the window boundaries.
@@ -97,7 +97,7 @@ class Window {
 	/**
 		Set the hardware mouse cursor position relative to window boundaries.
 	**/
-	public function setCursorPos( x : Int, y : Int ) : Void {
+	public function setCursorPos( x : Int, y : Int, emitEvent : Bool = false ) : Void {
 		throw "Not implemented";
 	}
 

--- a/hxd/Window.hx
+++ b/hxd/Window.hx
@@ -24,7 +24,9 @@ class Window {
 	**/
 	public var mouseClip(get, set) : Bool;
 	/**
-		Set the mouse movement input handling mode. See `MouseMode` for more details on each mode.
+		Set the mouse movement input handling mode.
+
+		@see `hxd.impl.MouseMode` for more details on each mode.
 	**/
 	public var mouseMode(default, set) : MouseMode = Absolute;
 	public var vsync(get, set) : Bool;

--- a/hxd/Window.hx
+++ b/hxd/Window.hx
@@ -1,5 +1,7 @@
 package hxd;
 
+import hxd.impl.MouseMode;
+
 enum DisplayMode {
 	Windowed;
 	Borderless;
@@ -15,7 +17,16 @@ class Window {
 	public var height(get, never) : Int;
 	public var mouseX(get, never) : Int;
 	public var mouseY(get, never) : Int;
+	@:deprecated("Use mouseMode = AbsoluteUnbound")
 	public var mouseLock(get, set) : Bool;
+	/**
+		If set, will restrain the mouse cursor within the window boundaries.
+	**/
+	public var mouseClip(get, set) : Bool;
+	/**
+		Set the mouse movement input handling mode. See `MouseMode` for more details on each mode.
+	**/
+	public var mouseMode(default, set) : MouseMode = Absolute;
 	public var vsync(get, set) : Bool;
 	public var isFocused(get, never) : Bool;
 
@@ -72,6 +83,13 @@ class Window {
 	public function setFullScreen( v : Bool ) : Void {
 	}
 
+	/**
+		Set the hardware mouse cursor position relative to window boundaries.
+	**/
+	public function setCursorPos( x : Int, y : Int ) : Void {
+		throw "Not implemented";
+	}
+
 	static var inst : Window = null;
 	public static function getInstance() : Window {
 		if( inst == null ) inst = new Window();
@@ -95,12 +113,25 @@ class Window {
 	}
 
 	function get_mouseLock() : Bool {
-		return false;
+		return mouseMode == AbsoluteUnbound;
 	}
 
 	function set_mouseLock( v : Bool ) : Bool {
-		if( v ) throw "Not implemented";
+		return set_mouseMode(v ? AbsoluteUnbound : Absolute) == AbsoluteUnbound;
+	}
+
+	function get_mouseClip() : Bool {
 		return false;
+	}
+
+	function set_mouseClip( v : Bool ) : Bool {
+		if ( v ) throw "Not implemented";
+		return false;
+	}
+
+	function set_mouseMode( v : MouseMode ) : MouseMode {
+		if ( v != Absolute ) throw "Not implemented";
+		return Absolute;
 	}
 
 	function get_vsync() : Bool return true;

--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -364,14 +364,6 @@ class Window {
 				curMouseX += e.movementX;
 				curMouseY += e.movementY;
 				event(new Event(EMove, curMouseX, curMouseY));
-			case AbsoluteWrap(_):
-				curMouseX += e.movementX;
-				curMouseY += e.movementY;
-				if (curMouseX < 0) curMouseX = width + (curMouseX % width);
-				else if (curMouseX >= width) curMouseX %= width;
-				if (curMouseY < 0) curMouseY = height + (curMouseY % height);
-				else if (curMouseY >= height) curMouseY %= height;
-				event(new Event(EMove, curMouseX, curMouseY));
 		}
 	}
 

--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -1,5 +1,6 @@
 package hxd;
 
+import js.Browser;
 import hxd.impl.MouseMode;
 
 enum DisplayMode {
@@ -278,12 +279,11 @@ class Window {
 		var forced = onMouseModeChange(mouseMode, v);
 		if (forced != null) v = forced;
 		
+		var target = canvas != null ? canvas : Browser.window.document.documentElement;
 		if ( v == Absolute ) {
-			if ( canvas != null ) canvas.ownerDocument.exitPointerLock();
-			else js.Browser.window.document.exitPointerLock();
+			if ( target.ownerDocument.pointerLockElement == target ) target.ownerDocument.exitPointerLock();
 		} else {
-			var target = canvas != null ? canvas : js.Browser.window.document.documentElement;
-			if (js.Browser.document.pointerLockElement != target) target.requestPointerLock();
+			if ( target.ownerDocument.pointerLockElement != target ) target.requestPointerLock();
 		}
 		return mouseMode = v;
 	}
@@ -296,8 +296,8 @@ class Window {
 	}
 
 	function onPointerLockChange( e : js.html.Event ) {
-		var lockTarget = canvas != null ? canvas : js.Browser.document.documentElement;
-		if ( js.Browser.document.pointerLockElement != lockTarget && mouseMode != Absolute ) {
+		var lockTarget = canvas != null ? canvas : Browser.document.documentElement;
+		if ( mouseMode != Absolute && lockTarget.ownerDocument.pointerLockElement != lockTarget ) {
 			// User cancelled out of the pointer lock by pressing escape or by other means: Switch to Absolute mode
 			mouseMode = Absolute;
 		}
@@ -307,9 +307,9 @@ class Window {
 		if ( mouseMode == Absolute ) {
 			if ( e.clientX != curMouseX || e.clientY != curMouseY ) onMouseMove(e);
 		} else {
-			var lockTarget = canvas != null ? canvas : js.Browser.document.documentElement;
+			var lockTarget = canvas != null ? canvas : Browser.document.documentElement;
 			// If we attempted to enter locked mode when browser didn't let us - try to enter locked mode on user click.
-			if ( js.Browser.document.pointerLockElement != lockTarget ) lockTarget.requestPointerLock();
+			if ( lockTarget.ownerDocument.pointerLockElement != lockTarget ) lockTarget.requestPointerLock();
 			if ( e.movementX != 0 || e.movementY != 0 ) onMouseMove(e);
 		}
 		var ev = new Event(EPush, mouseX, mouseY);

--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -21,7 +21,15 @@ class Window {
 	public var mouseY(get, never) : Int;
 	@:deprecated("Use mouseMode = AbsoluteUnbound(true)")
 	public var mouseLock(get, set) : Bool;
+	/**
+		If set, will restrain the mouse cursor within the window boundaries.
+	**/
 	public var mouseClip(get, set) : Bool;
+	/**
+		Set the mouse movement input handling mode.
+
+		@see `hxd.impl.MouseMode` for more details on each mode.
+	**/
 	public var mouseMode(default, set) : MouseMode = Absolute;
 	public var vsync(get, set) : Bool;
 	public var isFocused(get, never) : Bool;

--- a/hxd/impl/MouseMode.hx
+++ b/hxd/impl/MouseMode.hx
@@ -9,16 +9,39 @@ enum MouseMode {
 		Relative mouse movement mode. In this mode the mouse cursor is hidden and instead of `EMove` event the `callback` is invoked with relative mouse movement.
 
 		During Relative mouse mode the window mouse position is not updated.
-		If event is not cancelled and `propagate` set to true, the `EMove` event will be sent with last mouse position.
-		Use `Window.setMousePos` to modify the sent mouse position.
+
+		JS/HTML: Due to browser limitations, `restorePos` is always forced to `true`.
+		Mouse mode is force-changed to `Absolute` when user presses `Escape` or somehow else exits mouse capture mode.
+		Override `Window.onMouseModeChange` event in order to catch such cases.
+		
+		@param callback The callback to which the relative mouse movements are reported.
+		Unless event is cancelled, set `propagate` flag in order to emit an `EMove` event with current window cursor position.
+		Use `Window.setMousePos` to manually update the window cursor position.
+
+		@param restorePos If set, when changing mouse mode to `Absolute`, cursor position would be restores to the position it was on when this mode was enabled.
+		Otherwise mouse position is clipped to window boundaries.
 	**/
-	Relative(callback: hxd.Event->Void);
+	Relative(callback : hxd.Event -> Void, restorePos : Bool);
 	/**
 		Alternate relative mouse movement mode. In this mode the mouse cursor is hidden, and `EMove` can report mouse positions outside of window boundaries.
+		
+		JS/HTML: Due to browser limitations, `restorePos` is always forced to `true`.
+		Mouse mode is force-changed to `Absolute` when user presses `Escape` or somehow else exits mouse capture mode.
+		Override `Window.onMouseModeChange` event in order to catch such cases.
+		
+		@param restorePos If set, when changing mouse mode to `Absolute`, cursor position would be restored to the position it was on when this mode was enabled.
+		Otherwise mouse position is clipped to window boundaries.
 	**/
-	AbsoluteUnbound;
+	AbsoluteUnbound(restorePos : Bool);
 	/**
 		Alternate relative mouse movement mode. In this mode, the mouse cursor is hidden, and `EMove` event mouse position can wrap around the window boundaries.
+
+		JS/HTML: Due to browser limitations, `restorePos` is always forced to `true`.
+		Mouse mode is force-changed to `Absolute` when user presses `Escape` or somehow else exits mouse capture mode.
+		Override `Window.onMouseModeChange` event in order to catch such cases.
+		
+		@param restorePos If set, when changing mouse mode to `Absolute`, cursor position would be restored to the position it was on when this mode was enabled.
+		Otherwise mouse position remains unchanged.
 	**/
-	AbsoluteWrap;
+	AbsoluteWrap(restorePos : Bool);
 }

--- a/hxd/impl/MouseMode.hx
+++ b/hxd/impl/MouseMode.hx
@@ -2,6 +2,18 @@ package hxd.impl;
 
 /**
 	The mouse movement input handling mode.
+
+	**JS/HTML5 note**:
+	> Due to browser limitations, `restorePos` is ignored and always treated as `true`.
+	>
+	> Additionally, mouse mode will be forcefully changed to `Absolute` when user performs a browser action that exits the mouse capture mode,
+	e.g. pressing Escape or switching tabs/windows.
+	> Override `Window.onMouseModeChange` event in order to catch such cases.
+	>
+	> If mouse is not currently captured, but `mouseMode` is set to either `Relative` or `AbsoluteUnbound`,
+	mouse movement events are ignored and first click on the canvas is used to capture the mouse and hence discarded.
+	
+	@see `hxd.Window.mouseMode`
 **/
 enum MouseMode {
 	/**
@@ -13,27 +25,19 @@ enum MouseMode {
 
 		During Relative mouse mode the window mouse position is not updated.
 
-		JS/HTML: Due to browser limitations, `restorePos` is always forced to `true`.
-		Mouse mode is force-changed to `Absolute` when user presses `Escape` or somehow else exits mouse capture mode.
-		Override `Window.onMouseModeChange` event in order to catch such cases.
-		
 		@param callback The callback to which the relative mouse movements are reported.
 		Unless event is cancelled, set `propagate` flag in order to emit an `EMove` event with current window cursor position.
 		Use `Window.setMousePos` to manually update the window cursor position.
 
-		@param restorePos If set, when changing mouse mode to `Absolute`, cursor position would be restores to the position it was on when this mode was enabled.
-		Otherwise mouse position is clipped to window boundaries.
+		@param restorePos If set, when changing mouse mode to `Absolute`, cursor position would be restored to the position it was on when this mode was enabled.
+		Otherwise mouse position is clipped to window boundaries. Ignored and treated as `true` on JS.
 	**/
 	Relative(callback : hxd.Event -> Void, restorePos : Bool);
 	/**
 		Alternate relative mouse movement mode. In this mode the mouse cursor is hidden, and `EMove` can report mouse positions outside of window boundaries.
-		
-		JS/HTML: Due to browser limitations, `restorePos` is always forced to `true`.
-		Mouse mode is force-changed to `Absolute` when user presses `Escape` or somehow else exits mouse capture mode.
-		Override `Window.onMouseModeChange` event in order to catch such cases.
-		
+
 		@param restorePos If set, when changing mouse mode to `Absolute`, cursor position would be restored to the position it was on when this mode was enabled.
-		Otherwise mouse position is clipped to window boundaries.
+		Otherwise mouse position is clipped to window boundaries. Ignored and treated as `true` on JS.
 	**/
 	AbsoluteUnbound(restorePos : Bool);
 }

--- a/hxd/impl/MouseMode.hx
+++ b/hxd/impl/MouseMode.hx
@@ -1,0 +1,24 @@
+package hxd.impl;
+
+enum MouseMode {
+	/**
+		Default mouse movement mode. Causes `EMove` events in window coordinates.
+	**/
+	Absolute;
+	/**
+		Relative mouse movement mode. In this mode the mouse cursor is hidden and instead of `EMove` event the `callback` is invoked with relative mouse movement.
+
+		During Relative mouse mode the window mouse position is not updated.
+		If event is not cancelled and `propagate` set to true, the `EMove` event will be sent with last mouse position.
+		Use `Window.setMousePos` to modify the sent mouse position.
+	**/
+	Relative(callback: hxd.Event->Void);
+	/**
+		Alternate relative mouse movement mode. In this mode the mouse cursor is hidden, and `EMove` can report mouse positions outside of window boundaries.
+	**/
+	AbsoluteUnbound;
+	/**
+		Alternate relative mouse movement mode. In this mode, the mouse cursor is hidden, and `EMove` event mouse position can wrap around the window boundaries.
+	**/
+	AbsoluteWrap;
+}

--- a/hxd/impl/MouseMode.hx
+++ b/hxd/impl/MouseMode.hx
@@ -1,5 +1,8 @@
 package hxd.impl;
 
+/**
+	The mouse movement input handling mode.
+**/
 enum MouseMode {
 	/**
 		Default mouse movement mode. Causes `EMove` events in window coordinates.
@@ -33,15 +36,4 @@ enum MouseMode {
 		Otherwise mouse position is clipped to window boundaries.
 	**/
 	AbsoluteUnbound(restorePos : Bool);
-	/**
-		Alternate relative mouse movement mode. In this mode, the mouse cursor is hidden, and `EMove` event mouse position can wrap around the window boundaries.
-
-		JS/HTML: Due to browser limitations, `restorePos` is always forced to `true`.
-		Mouse mode is force-changed to `Absolute` when user presses `Escape` or somehow else exits mouse capture mode.
-		Override `Window.onMouseModeChange` event in order to catch such cases.
-		
-		@param restorePos If set, when changing mouse mode to `Absolute`, cursor position would be restored to the position it was on when this mode was enabled.
-		Otherwise mouse position remains unchanged.
-	**/
-	AbsoluteWrap(restorePos : Bool);
 }

--- a/samples/MouseApi.hx
+++ b/samples/MouseApi.hx
@@ -14,9 +14,7 @@ class MouseApi extends SampleApp {
 	var relativePath: Graphics;
 	var relX: Float;
 	var relY: Float;
-	#if js
 	var expectedMode: MouseMode;
-	#end
 
 	override function init() {
 		super.init();

--- a/samples/MouseApi.hx
+++ b/samples/MouseApi.hx
@@ -44,8 +44,6 @@ class MouseApi extends SampleApp {
 		});
 		// Mouse position would be able to leave the window boundaries, but clipped on exit.
 		addButton("AbsoluteUnbound", () -> window.mouseMode = expectedMode = AbsoluteUnbound(restore));
-		// Mouse position would wrap around the window boundaries.
-		addButton("AbsoluteWrap", () -> window.mouseMode = expectedMode = AbsoluteWrap(restore));
 		// When restoring to Absolute: Either clip mouse position or restore to where it entered relative mode.
 		addCheck("RestorePos", () -> restore, (v) -> restore = v);
 		// Would set propagate flag in Relative mode, allowing mouse movement events to pass trough.

--- a/samples/MouseApi.hx
+++ b/samples/MouseApi.hx
@@ -1,3 +1,4 @@
+import hxd.impl.MouseMode;
 import h2d.Graphics;
 import h2d.Text;
 import hxd.Key;
@@ -13,6 +14,9 @@ class MouseApi extends SampleApp {
 	var relativePath: Graphics;
 	var relX: Float;
 	var relY: Float;
+	#if js
+	var expectedMode: MouseMode;
+	#end
 
 	override function init() {
 		super.init();
@@ -31,19 +35,19 @@ class MouseApi extends SampleApp {
 
 		addText("MouseMode:");
 		// The default mouse mode behaves like a regular mouse.
-		addButton("Absolute", () -> window.mouseMode = Absolute);
+		addButton("Absolute", () -> window.mouseMode = expectedMode = Absolute);
 		// Callback will get relative mouse movement.
 		addButton("Relative", () -> {
-			window.mouseMode = Relative(onRelativeMove, restore);
+			window.mouseMode = expectedMode = Relative(onRelativeMove, restore);
 			relX = 0;
 			relY = 0;
 			relativePath.clear();
 			relativePath.setPosition(s2d.width>>1, s2d.height>>1);
 		});
 		// Mouse position would be able to leave the window boundaries, but clipped on exit.
-		addButton("AbsoluteUnbound", () -> window.mouseMode = AbsoluteUnbound(restore));
+		addButton("AbsoluteUnbound", () -> window.mouseMode = expectedMode = AbsoluteUnbound(restore));
 		// Mouse position would wrap around the window boundaries.
-		addButton("AbsoluteWrap", () -> window.mouseMode = AbsoluteWrap(restore));
+		addButton("AbsoluteWrap", () -> window.mouseMode = expectedMode = AbsoluteWrap(restore));
 		// When restoring to Absolute: Either clip mouse position or restore to where it entered relative mode.
 		addCheck("RestorePos", () -> restore, (v) -> restore = v);
 		// Would set propagate flag in Relative mode, allowing mouse movement events to pass trough.
@@ -59,13 +63,18 @@ class MouseApi extends SampleApp {
 		virtualCursor.lineTo(10, 10);
 		virtualCursor.lineTo(0, 16);
 		virtualCursor.endFill();
+
+		#if js
+		// On JS, browser can force-exit the relative mode. In which case switch back to one we want.
+		window.onMouseModeChange = (from, to) -> to != expectedMode ? from : to;
+		#end
 	}
 
 	override function update(dt:Float) {
 
 		var window = hxd.Window.getInstance();
 
-		if (Key.isReleased(Key.ESCAPE) || Key.isReleased(Key.MOUSE_RIGHT)) window.mouseMode = Absolute;
+		if (Key.isReleased(Key.ESCAPE) || Key.isReleased(Key.MOUSE_RIGHT)) window.mouseMode = expectedMode = Absolute;
 		state.text = "Current mode: " + window.mouseMode.getName() + "\nMouse position: " + window.mouseX + ", " + window.mouseY;
 		virtualCursor.visible = window.mouseMode != Absolute;
 		virtualCursor.setPosition(window.mouseX, window.mouseY);

--- a/samples/MouseApi.hx
+++ b/samples/MouseApi.hx
@@ -24,8 +24,10 @@ class MouseApi extends SampleApp {
 		addText("Press Escape or right click to restore to Absolute mouse mode");
 		state = addText("\n");
 
+		#if !js // Not supported on JS
 		// Lock the mouse within the window boundaries.
 		addCheck("MouseClip", () -> window.mouseClip, (v) -> window.mouseClip = v);
+		#end
 		
 		// Use setCursorPos in order to warp the mouse
 		// JS: Due to browser limitations only useful in relative modes to move the virtual cursor.

--- a/samples/MouseApi.hx
+++ b/samples/MouseApi.hx
@@ -1,0 +1,98 @@
+import h2d.Graphics;
+import h2d.Text;
+import hxd.Key;
+
+using hxd.Math;
+
+class MouseApi extends SampleApp {
+	
+	var state: Text;
+	var restore: Bool;
+	var propagate: Bool;
+	var virtualCursor: Graphics;
+	var relativePath: Graphics;
+	var relX: Float;
+	var relY: Float;
+
+	override function init() {
+		super.init();
+
+		var window = hxd.Window.getInstance();
+
+		addText("Press Escape or right click to restore to Absolute mouse mode");
+		state = addText("\n");
+
+		// Lock the mouse within the window boundaries.
+		addCheck("MouseClip", () -> window.mouseClip, (v) -> window.mouseClip = v);
+		
+		// Use setCursorPos in order to warp the mouse
+		// JS: Due to browser limitations only useful in relative modes to move the virtual cursor.
+		addButton("Set position to center", () -> window.setCursorPos(s2d.width>>1, s2d.height>>1));
+
+		addText("MouseMode:");
+		// The default mouse mode behaves like a regular mouse.
+		addButton("Absolute", () -> window.mouseMode = Absolute);
+		// Callback will get relative mouse movement.
+		addButton("Relative", () -> {
+			window.mouseMode = Relative(onRelativeMove, restore);
+			relX = 0;
+			relY = 0;
+			relativePath.clear();
+			relativePath.setPosition(s2d.width>>1, s2d.height>>1);
+		});
+		// Mouse position would be able to leave the window boundaries, but clipped on exit.
+		addButton("AbsoluteUnbound", () -> window.mouseMode = AbsoluteUnbound(restore));
+		// Mouse position would wrap around the window boundaries.
+		addButton("AbsoluteWrap", () -> window.mouseMode = AbsoluteWrap(restore));
+		// When restoring to Absolute: Either clip mouse position or restore to where it entered relative mode.
+		addCheck("RestorePos", () -> restore, (v) -> restore = v);
+		// Would set propagate flag in Relative mode, allowing mouse movement events to pass trough.
+		addCheck("Propagate", () -> propagate, (v) -> propagate = v);
+
+		relativePath = new Graphics();
+		s2d.addChildAt(relativePath, 0);
+
+		virtualCursor = new Graphics(s2d);
+		virtualCursor.lineStyle(1);
+		virtualCursor.beginFill(0xffffff);
+		virtualCursor.moveTo(0, 0);
+		virtualCursor.lineTo(10, 10);
+		virtualCursor.lineTo(0, 16);
+		virtualCursor.endFill();
+	}
+
+	override function update(dt:Float) {
+
+		var window = hxd.Window.getInstance();
+
+		if (Key.isReleased(Key.ESCAPE) || Key.isReleased(Key.MOUSE_RIGHT)) window.mouseMode = Absolute;
+		state.text = "Current mode: " + window.mouseMode.getName() + "\nMouse position: " + window.mouseX + ", " + window.mouseY;
+		virtualCursor.visible = window.mouseMode != Absolute;
+		virtualCursor.setPosition(window.mouseX, window.mouseY);
+
+	}
+
+	function onRelativeMove(e: hxd.Event) {
+		// Draw the movement segment and keep Graphics centered.
+		relativePath.x -= e.relX;
+		relativePath.y -= e.relY;
+		relativePath.lineStyle(1, Std.int(((Math.cos(relX * .05) + 1)) / 2 * 0xff) << 16 | Std.int(((Math.sin(relY * .05) + 1)) / 2 * 0xff) << 8 | 0xff, 1);
+		relativePath.moveTo(relX, relY);
+		relX += e.relX;
+		relY += e.relY;
+		relativePath.lineTo(relX, relY);
+		relativePath.lineStyle();
+
+		// Since in relative mode mouse position is not updated - update it manually.
+		var window = hxd.Window.getInstance();
+		if (propagate) {
+			window.setCursorPos((window.mouseX + Std.int(e.relX)).iclamp(0, window.width), (window.mouseY + Std.int(e.relY)).iclamp(0, window.height));
+			e.propagate = true;
+		}
+	}
+
+	static function main() {
+		new MouseApi();
+	}
+
+}


### PR DESCRIPTION
Integrates newly added mouse handling APIs into Heaps.
Adds 3 new features to `hxd.Window`:
* `mouseClip` - would restrain the mouse position within the window boundaries (actually extremely important for RTS games when using multi-monitor setup, so I expect to see that being added in Dune/Wartales/Northgard ;) Nothing is more infuriating than accidentally unfocusing the game because you moved the mouse a bit too fast and instead of stopping at the screen edge you end up clicking outside of the game)
* `mouseMode` - the mouse movement input mode.
* `setCursorPos` - what it says on the tin. Allows manipulating user cursor position. Also useful for Relative mouse mode, since real mouse position is undefined when relative mouse mode is enabled due to backend differences.
* `mouseLock` is deprecated in favor of `MouseMode.AbsoluteUnbound`.

I've added the following modes:
* `Absolute` - default and classic behavior of "mouse is where hardware cursor is".
* `Relative(callback: Event->Void)` - sets the relative mouse mode, and instead of `EMove` will invoke the callback with `relX` / `relY` being relative movement of the mouse. Callback can set `propagate` flag (and not set `cancel`), in which case `curMouseX` / `curMouseY` would be set to `relX` / `relY` and `EMove` event would be sent as usual.
* `AbsoluteUnbound` - what current `mouseLock` does on JS: Will enable relative mouse mode and would allow virtual mouse position to exit the window boundaries.
* `AbsoluteWrap` - same, but instead of exiting boundaries it would wrap around.

Additionally I modified `CameraController` code so it would enter `AbsoluteUnbound` mode when rotating, allowing for a much better rotation experience.

This is a draft implementation because for now it's only DX implementation (still need to add SDL and JS + test), as well as I'd like some feedback on API itself while I still work on it, instead of having to rework big chunks of it afterwards.

- [x] Finalize public API
- [x] DirectX implementation
- [x] SDL implementation
- [x] JS implementation

Things I see issues with:
* Due to backends inconsistencies with each other, when entering relative mouse mode, the hardware cursor position becomes undefined, and when exiting the relative mode - cursor position could be anywhere. So, we need to either have an explicit warning in documentation about hardware mouse position being undefined or consistently "freeze" it in place when entering relative mode. However there's a problem with `AbsoluteUnbound` and `AbsoluteWrap` as those only move virtual mouse position. Do we restore position at the time we entered relative mode, or to current virtual position? What to do when we exit while mouse position is outside window area?
* Pressing Escape on JS would force-unlock the mouse. It has to be handled somehow. Either by having callback handle the cancel exit event or adding `onCancel` callback, in which case `AbsoluteUnbound` and `AbsoluteWrap` also should get `onCancel` argument. Or by automatically re-locking it on user input, in which case we need to decide if input that locks the mouse should be discarded or sent to Heaps regardless, and also how to handle mouse events while mouse is not locked. (discard or pass trough?)
* Current implementation does not properly handle mouse movement during MouseUp/MouseDown events, I plan to fix that.

For automation:
Close #568 