### PR TITLE
Fix multiline TextInput when moving selection outside of TextInput

### DIFF
--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -456,6 +456,7 @@ class TextInput extends Text {
 	function textPos( x : Float, y : Float ) {
 		x += scrollX;
 		var lineIndex = Math.floor(y / font.lineHeight);
+		lineIndex = Math.floor(hxd.Math.clamp(lineIndex, 0, lines.length - 1));
 		var lines = getAllLines();
 		var selectedLine = lines[lineIndex];
 		var pos = 0;

--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -456,8 +456,8 @@ class TextInput extends Text {
 	function textPos( x : Float, y : Float ) {
 		x += scrollX;
 		var lineIndex = Math.floor(y / font.lineHeight);
-		lineIndex = Math.floor(hxd.Math.clamp(lineIndex, 0, lines.length - 1));
 		var lines = getAllLines();
+		lineIndex = hxd.Math.iclamp(lineIndex, 0, lines.length - 1);
 		var selectedLine = lines[lineIndex];
 		var pos = 0;
 		for(i in 0...lineIndex) {


### PR DESCRIPTION
Fixes a crash when moving the mouse outside the input box while selecting:

https://github.com/HeapsIO/heaps/pull/1089#issuecomment-1232760687