### PR TITLE
Fix compilation for lua

### DIFF
--- a/hxd/fmt/hmd/Library.hx
+++ b/hxd/fmt/hmd/Library.hx
@@ -241,7 +241,7 @@ class Library {
 				}
 				buf.indexes[i] = rid - 1;
 			}
-			#if neko
+			#if (neko||lua)
 			buf.vertexes = haxe.ds.Vector.fromArrayCopy(vertexes.getNative());
 			#else
 			buf.vertexes = haxe.ds.Vector.fromData(vertexes.getNative());


### PR DESCRIPTION
- Building some Heaps code with a Lua target failed with the following error:

```
/usr/local/lib/haxe/lib/heaps/1,9,1/hxd/fmt/hmd/Library.hx:252: characters 43-63 : hxd._FloatBuffer.InnerData should be haxe.ds._Vector.VectorData<Unknown<0>>
/usr/local/lib/haxe/lib/heaps/1,9,1/hxd/fmt/hmd/Library.hx:252: characters 43-63 : ... For function argument 'data'
```

Adding Lua alongside Neko in this statement makes the build work.

I'm not sure how I can find the Stacktrace leading to this error but I can dig further if you help me :)