### PR TITLE
JS: Fix input bugs with window resize.

### DIFF
--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -123,9 +123,9 @@ class Window {
 				checkResize();
 			});
 			observer.observe(canvas);
-		} else {
-			js.Browser.window.addEventListener("resize", checkResize);
 		}
+
+		js.Browser.window.addEventListener("resize", checkResize);
 
 		js.Browser.document.addEventListener("pointerlockchange", onPointerLockChange);
 


### PR DESCRIPTION
Fixes an issue with mouse positioning being wrong in case window got resized but canvas didn't. 

Honestly entire mouse positioning should be rewritten and not rely on canvas bounding box arbitrarily fetched at resize events/init. Mouse input likely also will bug out in case of window scroll and canvas being not in the window-position of the bounding box.