### PR TITLE
Fixed Variable ID allocation in linker

### DIFF
--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -292,9 +292,12 @@ typedef ShaderData = {
 }
 
 class Tools {
-
-	static var UID = 0;
-
+	#if macro
+	static var UID = -1;
+	#else
+	static var UID = 1000; // offset initial ID to avoid conflict with linker generated ones
+	#end
+	
 	public static var SWIZ = Component.createAll();
 	public static var MAX_CHANNELS_BITS = 3;
 

--- a/hxsl/Linker.hx
+++ b/hxsl/Linker.hx
@@ -148,7 +148,8 @@ class Linker {
 				return v2;
 			}
 		}
-		var vid = allVars.length + 1;
+		// var vid = allVars.length + 1;  // I think this is incorrect, but I'm not certain
+		var vid = Tools.allocVarId();
 		var v2 : TVar = {
 			id : vid,
 			name : vname,

--- a/hxsl/Linker.hx
+++ b/hxsl/Linker.hx
@@ -148,8 +148,7 @@ class Linker {
 				return v2;
 			}
 		}
-		// var vid = allVars.length + 1;  // I think this is incorrect, but I'm not certain
-		var vid = Tools.allocVarId();
+		var vid = allVars.length + 1;
 		var v2 : TVar = {
 			id : vid,
 			name : vname,


### PR DESCRIPTION
Duplicate IDs were being created due to two different methods of UID generation.

I'll remove the comment before submitting if this change is reviewed and approved.