### PR TITLE
Fix multiply blend mode

### DIFF
--- a/h3d/mat/Pass.hx
+++ b/h3d/mat/Pass.hx
@@ -113,7 +113,7 @@ class Pass {
 			blend(OneMinusDstColor, One);
 			blendAlphaSrc = One;
 		case Multiply: // Out = Dst * Src + 0 * Dst
-			blend(DstColor, One);
+			blend(DstColor, Zero);
 			blendAlphaSrc = One;
 		case AlphaMultiply: // Out = Dst * Src + (1 - SrcA) * Dst
 			blend(DstColor, OneMinusSrcAlpha);


### PR DESCRIPTION
It seems that in a previous update, a small mistake in the Multiple blend mode was introduced. This fixes it so that Multiply works properly.