### PR TITLE
Implement Sampler.grad method for HXSL

### DIFF
--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -208,6 +208,7 @@ enum TGlobal {
 	TextureLod;
 	Texel;
 	TextureSize;
+	Grad;
 	// ...other texture* operations
 	// constructors
 	ToInt;
@@ -243,6 +244,7 @@ enum TGlobal {
 	ChannelReadLod;
 	ChannelFetch;
 	ChannelTextureSize;
+	ChannelGrad;
 	Trace;
 	// instancing
 	VertexID;

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -84,6 +84,12 @@ class Checker {
 					{ args : [ { name: "tex", type: TSampler2D }, { name: "pos", type: ivec2 }, { name: "lod", type: TInt } ], ret: vec4 },
 					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "pos", type: ivec3 }, { name: "lod", type: TInt } ], ret: vec4 },
 				];
+			case Grad:
+				[
+					{ args : [ { name: "tex", type: TSampler2D }, { name: "pos", type: vec2 }, { name: "dPdx", type: vec2 }, { name: "dPdy", type: vec2 } ], ret: vec4 },
+					{ args : [ { name: "tex", type: TSampler2DArray }, { name: "pos", type: vec3 }, { name: "dPdx", type: vec2 }, { name: "dPdy", type: vec2 } ], ret: vec4 },
+					{ args : [ { name: "tex", type: TSamplerCube }, { name: "pos", type: vec3 }, { name: "dPdx", type: vec3 }, { name: "dPdy", type: vec3 } ], ret: vec4 },
+				];
 			case TextureSize:
 				[
 					{ args : [ { name: "tex", type: TSampler2D } ], ret: vec2 },
@@ -165,6 +171,13 @@ class Checker {
 					{ args : [ { name : "channel", type : TChannel(2) }, { name : "pos", type : ivec2 }, { name : "lod", type : TInt } ], ret : vec2 },
 					{ args : [ { name : "channel", type : TChannel(3) }, { name : "pos", type : ivec2 }, { name : "lod", type : TInt } ], ret : vec3 },
 					{ args : [ { name : "channel", type : TChannel(4) }, { name : "pos", type : ivec2 }, { name : "lod", type : TInt } ], ret : vec4 },
+				];
+			case ChannelGrad:
+				[
+					{ args : [ { name: "channel", type: TChannel(1) }, { name: "pos", type: vec2 }, { name: "dPdx", type: vec2 }, { name: "dPdy", type: vec2 } ], ret: TFloat },
+					{ args : [ { name: "channel", type: TChannel(2) }, { name: "pos", type: vec2 }, { name: "dPdx", type: vec2 }, { name: "dPdy", type: vec2 } ], ret: vec2 },
+					{ args : [ { name: "channel", type: TChannel(3) }, { name: "pos", type: vec2 }, { name: "dPdx", type: vec2 }, { name: "dPdy", type: vec2 } ], ret: vec3 },
+					{ args : [ { name: "channel", type: TChannel(4) }, { name: "pos", type: vec2 }, { name: "dPdx", type: vec2 }, { name: "dPdy", type: vec2 } ], ret: vec4 },
 				];
 			case ChannelTextureSize:
 				[
@@ -919,6 +932,8 @@ class Checker {
 			case ["getLod", TChannel(_)]: ChannelReadLod;
 			case ["fetch"|"fetchLod", TSampler2D|TSampler2DArray]: Texel;
 			case ["fetch"|"fetchLod", TChannel(_)]: ChannelFetch;
+			case ["grad", TSampler2D|TSampler2DArray|TSamplerCube]: Grad;
+			case ["grad", TChannel(_)]: ChannelGrad;
 			case ["size", TSampler2D|TSampler2DArray|TSamplerCube]: TextureSize;
 			case ["size", TChannel(_)]: ChannelTextureSize;
 			default: null;

--- a/hxsl/Dce.hx
+++ b/hxsl/Dce.hx
@@ -238,6 +238,9 @@ class Dce {
 		case TCall({ e : TGlobal(ChannelFetch) }, [_, pos, lod, { e : TConst(CInt(cid)) }]):
 			var c = channelVars[cid];
 			return { e : TCall({ e : TGlobal(Texel), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(pos,true), mapExpr(lod,true)]), t : TVoid, p : e.p };
+		case TCall({ e : TGlobal(ChannelGrad) }, [_, pos, dPdx, dPdy, { e: TConst(CInt(cid)) }]):
+			var c = channelVars[cid];
+			return { e : TCall({ e: TGlobal(Grad), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }, mapExpr(pos,true), mapExpr(dPdx,true), mapExpr(dPdy,true)]), t : TVoid, p : e.p };
 		case TCall({ e : TGlobal(ChannelTextureSize) }, [_, { e : TConst(CInt(cid)) }]):
 			var c = channelVars[cid];
 			return { e : TCall({ e : TGlobal(TextureSize), p : e.p, t : TVoid }, [{ e : TVar(c), t : c.type, p : e.p }]), t : TVoid, p : e.p };

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -277,6 +277,8 @@ class GlslOut {
 			// 	return "_texelFetch";
 			// else
 				return "texelFetch";
+		case Grad:
+			return "textureGrad";
 		case TextureSize:
 			switch( args[0].t ) {
 			case TSampler2D, TChannel(_):

--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -293,13 +293,15 @@ class HlslOut {
 			var acc = varAccess.get(v.id);
 			if( acc != null ) add(acc);
 			ident(v);
-		case TCall({ e : TGlobal(g = (Texture | TextureLod)) }, args):
+		case TCall({ e : TGlobal(g = (Texture | TextureLod | Grad)) }, args):
 			addValue(args[0], tabs);
 			switch( g ) {
 			case Texture:
 				add(isVertex ? ".SampleLevel(" : ".Sample(");
 			case TextureLod:
 				add(".SampleLevel(");
+			case Grad:
+				add(".SampleGrad(");
 			default:
 				throw "assert";
 			}


### PR DESCRIPTION
Adds support for GLSL [`textureGrad`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/textureGrad.xhtml) / HLSL [`SampleGrad`](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-to-samplegrad) methods as `Sampler.grad()`.
Requested by CLYDE from Discord.

Sample shader (ported from [this](https://www.shadertoy.com/view/tttGzj) ShaderToy shader):
```haxe
class HxslGradTest extends hxsl.Shader {

	static var SRC = {
		
		@borrow(h3d.shader.Base2d) var texture: Sampler2D;

		@global var time: Float;
		var calculatedUV: Vec2;
		var pixelColor: Vec4;

		function fragment() {
			var blur = pow(.0625 - cos(calculatedUV.x * 20.0 + time) * .0625, 2.);
			var grad = vec2(blur, blur);
			pixelColor =
				texture.grad(calculatedUV + .5 * vec2( blur, blur), grad, grad) * .25 +
				texture.grad(calculatedUV + .5 * vec2( blur,-blur), grad, grad) * .25 +
				texture.grad(calculatedUV + .5 * vec2(-blur, blur), grad, grad) * .25 +
				texture.grad(calculatedUV + .5 * vec2(-blur,-blur), grad, grad) * .25;
		}
	}

}
```