### PR TITLE
[HXSL] Enable ability to write to arrays.

### DIFF
--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -338,6 +338,9 @@ class Checker {
 		case TSwiz(e, _):
 			checkWrite(e);
 			return;
+		case TArray(e, _):
+			checkWrite(e);
+			return;
 		default:
 		}
 		error("This expression cannot be assigned", e.p);

--- a/hxsl/Dce.hx
+++ b/hxsl/Dce.hx
@@ -149,6 +149,14 @@ class Dce {
 			writeTo.pop();
 			if( isAffected.indexOf(v) < 0 )
 				isAffected.push(v);
+		case TBinop(OpAssign | OpAssignOp(_), { e : TArray({ e: TVar(v) }, i) }, e):
+			var v = get(v);
+			writeTo.push(v);
+			check(i, writeTo, isAffected);
+			check(e, writeTo, isAffected);
+			writeTo.pop();
+			if ( isAffected.indexOf(v) < 0 )
+				isAffected.push(v);
 		case TBlock(el):
 			var noWrite = [];
 			for( i in 0...el.length )
@@ -224,7 +232,7 @@ class Dce {
 				count++;
 			}
 			return { e : TBlock(out), p : e.p, t : e.t };
-		case TVarDecl(v,_) | TBinop(OpAssign | OpAssignOp(_), { e : (TVar(v) | TSwiz( { e : TVar(v) }, _)) }, _) if( !get(v).used ):
+		case TVarDecl(v,_) | TBinop(OpAssign | OpAssignOp(_), { e : (TVar(v) | TSwiz( { e : TVar(v) }, _) | TArray( { e : TVar(v) }, _)) }, _) if( !get(v).used ):
 			return { e : TConst(CNull), t : e.t, p : e.p };
 		case TCall({ e : TGlobal(ChannelRead) }, [_, uv, { e : TConst(CInt(cid)) }]):
 			var c = channelVars[cid];


### PR DESCRIPTION
Allows writing to array types as it is legal in both GLSL(+WGL) and HLSL. 
Feature requested by tee from Discord.

Same as #1127 I tested it on SDL, DX and JS targets, and there are no compatibility issues.

Test shader used:
```haxe

class WriteShader extends hxsl.Shader {

	static var SRC = {

		var pixelColor: Vec4;

		function fragment()
		{
			var p:Array<Vec2,3> = [vec2(0.0),vec2(0.0),vec2(0.0)];

			var i = 0;
			p[i]=vec2(1.0,1.0);

			var g = vec2(1.0,1.0);
			p[1]=g;

			pixelColor = vec4(p[0].x,p[1].y,p[2].x,1.0);
		}
	}

}
```