### PR TITLE
[HXSL] Provide better errors on display

### DIFF
--- a/hxsl/Macros.hx
+++ b/hxsl/Macros.hx
@@ -436,7 +436,7 @@ class Macros {
 								fields.push(f);
 					} catch( e : Ast.Error ) {
 						fields.remove(f);
-						Context.error(e.msg, e.pos);
+						Context.fatalError(e.msg, e.pos);
 					}
 				default:
 				}


### PR DESCRIPTION
By using `Context.fatalError` with position data provided in macro context, instead of non-helpful "Build failure" on `class` it would highlight the actual error position and error text.

Currently if there's an error in the shader:
![image](https://user-images.githubusercontent.com/1061373/224866981-f76f8181-1e8f-49c4-a7fd-4cab3ed6dc34.png)
With this PR:
![image](https://user-images.githubusercontent.com/1061373/224867012-3dcd2f76-02cf-425d-92d3-412da72c35b8.png)
