### PR TITLE
fix use hldx on ime and custom font bug

### DIFF
--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -266,7 +266,9 @@ class TextInput extends Text {
 				return;
 			if( e.charCode != 0 && canEdit ) {
 
-				if( !font.hasChar(e.charCode) ) return; // don't allow chars not supported by font
+				if( !font.hasChar(e.charCode) ) return; // don't allow chars not supported by font				
+				if(e.charCode == 8) return;
+				if(K.isDown(K.CTRL)) return;
 
 				beforeChange();
 				if( selectionRange != null )

--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -267,7 +267,7 @@ class TextInput extends Text {
 			if( e.charCode != 0 && canEdit ) {
 
 				if( !font.hasChar(e.charCode) ) return; // don't allow chars not supported by font				
-				if(e.charCode == 8) return;
+				if(e.charCode == K.BACKSPACE) return;
 				if(K.isDown(K.CTRL)) return;
 
 				beforeChange();


### PR DESCRIPTION
In hldx, if I customize a font (for example, it is Korean, Chinese), then I need to set hasChar to force it to return true, because the mapping of characters is generated in real time and it is impossible to traverse. But if I force hasChar to return true, it will cause font.hasChar to then go down and hldx will send ctrl and delete key as charkey, causing the program to go wrong.