### PR TITLE
Added the possibility to specify and auto-call a software keyboard for all TextInput

### DIFF
--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -55,9 +55,8 @@ class TextInput extends Text {
 		When disabled, showSoftwareKeyboard will not be called.
 	**/
 	public var useSoftwareKeyboard : Bool = true;
-	public static dynamic function showSoftwareKeyboard(target:TextInput, onTextChange:String->Void, onCursorMove:Int->Void, onFinish:()->Void) {}
-	public static dynamic function hideSoftwareKeyboard() {}
-	public static dynamic function updateSoftwareKeyboard(text:String, cursorIndex:Int) {}
+	public static dynamic function showSoftwareKeyboard(target:TextInput) {}
+	public static dynamic function hideSoftwareKeyboard(target:TextInput) {}
 
 	var interactive : h2d.Interactive;
 	var cursorText : String;
@@ -131,22 +130,13 @@ class TextInput extends Text {
 		};
 		interactive.onFocus = function(e) {
 			onFocus(e);
-			if ( useSoftwareKeyboard && canEdit ) {
-				showSoftwareKeyboard(this, function(str) {
-						if (text != str) {
-							beforeChange();
-							text = str;
-							onChange();
-							if (text != str)
-								updateSoftwareKeyboard(text, cursorIndex);
-						}
-					}, (pos) -> cursorIndex = pos, () -> interactive.blur());
-			}
+			if ( useSoftwareKeyboard && canEdit )
+				showSoftwareKeyboard(this);
 		}
 		interactive.onFocusLost = function(e) {
 			cursorIndex = -1;
 			selectionRange = null;
-			hideSoftwareKeyboard();
+			hideSoftwareKeyboard(this);
 			onFocusLost(e);
 		};
 

--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -51,6 +51,15 @@ class TextInput extends Text {
 	**/
 	public var backgroundColor(get, set) : Null<Int>;
 
+	/**
+		When disabled, showSoftwareKeyboard will not be called.
+	 */
+	public var useSoftwareKeyboard : Bool = true;
+	/**
+		If defined, will be called during onFocus. The function should return null if edit is canceled.
+	*/
+	public static var showSoftwareKeyboard : (text:String, multiline:Bool) -> String;
+
 	var interactive : h2d.Interactive;
 	var cursorText : String;
 	var cursorX : Float;
@@ -121,6 +130,20 @@ class TextInput extends Text {
 			onTextInput(e);
 			handleKey(e);
 		};
+		interactive.onFocus = function(e) {
+			onFocus(e);
+			if ( showSoftwareKeyboard != null && useSoftwareKeyboard && canEdit ) {
+				haxe.Timer.delay(function () {
+					var str = showSoftwareKeyboard(text, multiline);
+					if (str != null) {
+						beforeChange();
+						text = str;
+						onChange();
+					}
+					interactive.blur();
+				}, 0);
+			}
+		}
 		interactive.onFocusLost = function(e) {
 			cursorIndex = -1;
 			selectionRange = null;
@@ -142,7 +165,6 @@ class TextInput extends Text {
 
 		interactive.onKeyUp = function(e) onKeyUp(e);
 		interactive.onRelease = function(e) onRelease(e);
-		interactive.onFocus = function(e) onFocus(e);
 		interactive.onKeyUp = function(e) onKeyUp(e);
 		interactive.onMove = function(e) onMove(e);
 		interactive.onOver = function(e) onOver(e);

--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -53,12 +53,11 @@ class TextInput extends Text {
 
 	/**
 		When disabled, showSoftwareKeyboard will not be called.
-	 */
+	**/
 	public var useSoftwareKeyboard : Bool = true;
-	/**
-		If defined, will be called during onFocus. The function should return null if edit is canceled.
-	*/
-	public static var showSoftwareKeyboard : (text:String, multiline:Bool) -> String;
+	public static dynamic function showSoftwareKeyboard(target:TextInput, onTextChange:String->Void, onCursorMove:Int->Void, onFinish:()->Void) {}
+	public static dynamic function hideSoftwareKeyboard() {}
+	public static dynamic function updateSoftwareKeyboard(text:String, cursorIndex:Int) {}
 
 	var interactive : h2d.Interactive;
 	var cursorText : String;
@@ -132,21 +131,22 @@ class TextInput extends Text {
 		};
 		interactive.onFocus = function(e) {
 			onFocus(e);
-			if ( showSoftwareKeyboard != null && useSoftwareKeyboard && canEdit ) {
-				haxe.Timer.delay(function () {
-					var str = showSoftwareKeyboard(text, multiline);
-					if (str != null) {
-						beforeChange();
-						text = str;
-						onChange();
-					}
-					interactive.blur();
-				}, 0);
+			if ( useSoftwareKeyboard && canEdit ) {
+				showSoftwareKeyboard(this, function(str) {
+						if (text != str) {
+							beforeChange();
+							text = str;
+							onChange();
+							if (text != str)
+								updateSoftwareKeyboard(text, cursorIndex);
+						}
+					}, (pos) -> cursorIndex = pos, () -> interactive.blur());
 			}
 		}
 		interactive.onFocusLost = function(e) {
 			cursorIndex = -1;
 			selectionRange = null;
+			hideSoftwareKeyboard();
 			onFocusLost(e);
 		};
 


### PR DESCRIPTION
The idea is to add support software keyboard on some platforms (e.g. console or mobile) for all TextInput created, with a single var `h2d.TextInput.showSoftwareKeyboard` to be assigned at the start of a program.
It can then be disable in individual TextInput, if needed, by setting `useSoftwareKeyboard` to false.
When `h2d.TextInput.showSoftwareKeyboard` is set, it will be called when TextInput is focused. After the input or canceled, the TextInput will be automatically blur to allow focus it again.