### PR TITLE
Adjust to upcoming Haxe resolution changes

### DIFF
--- a/h3d/Quat.hx
+++ b/h3d/Quat.hx
@@ -253,7 +253,7 @@ class Quat {
 		// ln()
 		var r = Math.sqrt(x*x+y*y+z*z);
 		var t = r > Math.EPSILON ? Math.atan2(r,w)/r : 0;
-		w = 0.5 * Math.log(w*w+x*x+y*y+z*z);
+		w = 0.5 * std.Math.log(w*w+x*x+y*y+z*z);
 		x *= t;
 		y *= t;
 		z *= t;
@@ -264,7 +264,7 @@ class Quat {
 		w *= v;
 		// exp
 		var r = Math.sqrt(x*x+y*y+z*z);
-		var et = Math.exp(w);
+		var et = std.Math.exp(w);
 		var s = r > Math.EPSILON ? et *Math.sin(r)/r : 0;
 		w = et * Math.cos(r);
 		x *= s;

--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -141,6 +141,30 @@ enum ExprDef {
 	EMeta( name : String, args : Array<Expr>, e : Expr );
 }
 
+enum TExprDef {
+	TConst( c : Const );
+	TVar( v : TVar );
+	TGlobal( g : TGlobal );
+	TParenthesis( e : TExpr );
+	TBlock( el : Array<TExpr> );
+	TBinop( op : Binop, e1 : TExpr, e2 : TExpr );
+	TUnop( op : Unop, e1 : TExpr );
+	TVarDecl( v : TVar, ?init : TExpr );
+	TCall( e : TExpr, args : Array<TExpr> );
+	TSwiz( e : TExpr, regs : Array<Component> );
+	TIf( econd : TExpr, eif : TExpr, eelse : Null<TExpr> );
+	TDiscard;
+	TReturn( ?e : TExpr );
+	TFor( v : TVar, it : TExpr, loop : TExpr );
+	TContinue;
+	TBreak;
+	TArray( e : TExpr, index : TExpr );
+	TArrayDecl( el : Array<TExpr> );
+	TSwitch( e : TExpr, cases : Array<{ values : Array<TExpr>, expr:TExpr }>, def : Null<TExpr> );
+	TWhile( e : TExpr, loop : TExpr, normalWhile : Bool );
+	TMeta( m : String, args : Array<Const>, e : TExpr );
+}
+
 typedef TVar = {
 	var id : Int;
 	var name : String;
@@ -257,30 +281,6 @@ enum Component {
 	Y;
 	Z;
 	W;
-}
-
-enum TExprDef {
-	TConst( c : Const );
-	TVar( v : TVar );
-	TGlobal( g : TGlobal );
-	TParenthesis( e : TExpr );
-	TBlock( el : Array<TExpr> );
-	TBinop( op : Binop, e1 : TExpr, e2 : TExpr );
-	TUnop( op : Unop, e1 : TExpr );
-	TVarDecl( v : TVar, ?init : TExpr );
-	TCall( e : TExpr, args : Array<TExpr> );
-	TSwiz( e : TExpr, regs : Array<Component> );
-	TIf( econd : TExpr, eif : TExpr, eelse : Null<TExpr> );
-	TDiscard;
-	TReturn( ?e : TExpr );
-	TFor( v : TVar, it : TExpr, loop : TExpr );
-	TContinue;
-	TBreak;
-	TArray( e : TExpr, index : TExpr );
-	TArrayDecl( el : Array<TExpr> );
-	TSwitch( e : TExpr, cases : Array<{ values : Array<TExpr>, expr:TExpr }>, def : Null<TExpr> );
-	TWhile( e : TExpr, loop : TExpr, normalWhile : Bool );
-	TMeta( m : String, args : Array<Const>, e : TExpr );
 }
 
 typedef TExpr = { e : TExprDef, t : Type, p : Position }


### PR DESCRIPTION
I'm changing resolution behavior in https://github.com/HaxeFoundation/haxe/pull/11168, which requires two adjustments:

1. Because enum constructors are no longer prioritized over types, the lexical order matters. Our resolution algorithm specifies that when importing a module, the first occurrence of an identifier in that module is the one we resolve to. This makes it necessary to declare `TExprDef` _before_ `TVar` so that we resolve to `TExprDef.TVar` instead of the `TVar` typedef.

2. The situation in Quat.hx is very strange, see https://github.com/HaxeFoundation/haxe/pull/11168#issuecomment-1517250449 for an explanation.

Both changes should not affect anything in other Haxe versions.