### PR TITLE
Some updates and additions to the SAO sample

### DIFF
--- a/samples/SampleApp.hx
+++ b/samples/SampleApp.hx
@@ -28,7 +28,7 @@ class SampleApp extends hxd.App {
 		return f;
 	}
 
-	function addSlider( label : String, get : Void -> Float, set : Float -> Void, min : Float = 0., max : Float = 1. ) {
+	function addSlider( label : String, get : Void -> Float, set : Float -> Void, min : Float = 0., max : Float = 1., intValues = false ) {
 		var f = new h2d.Flow(fui);
 
 		f.horizontalSpacing = 5;
@@ -47,12 +47,13 @@ class SampleApp extends hxd.App {
 		tf.text = "" + hxd.Math.fmt(sli.value);
 		sli.onChange = function() {
 			set(sli.value);
-			tf.text = "" + hxd.Math.fmt(sli.value);
+			tf.text = "" + (intValues ? Std.int(sli.value) : hxd.Math.fmt(sli.value));
 			f.needReflow = true;
 		};
 		tf.onChange = function() {
-			var v = Std.parseFloat(tf.text);
-			if( Math.isNaN(v) ) return;
+			var p = Std.parseFloat(tf.text);
+			if( Math.isNaN(p) ) return;
+			var v = intValues ? Std.int(p) : p;
 			sli.value = v;
 			set(v);
 		};


### PR DESCRIPTION
Playing with the SAO sample project, I found the edges to be a bit harsh, and the shadows dark and a bit ugly. Some tweaking could make it much prettier. So I:

- added an option to use the FXAA shader (on the color texture... I just copied what Pbr was doing, seems to work?)
- added options to control the shadows parameters
- reduced the default shadow power from 30 to 8, and quality from 0.5 to 1.0
- moved the vsync option from keyboard `V` to checkbox
- added keyboard shortcut hint
- added an option to make `addSlider` only display and set integer values (for samples and shadow size)

Before:

![Selection_1761](https://github.com/HeapsIO/heaps/assets/2192439/a36e5c73-9933-4f88-9a9f-10291c19a22b)

After:

![image](https://github.com/HeapsIO/heaps/assets/2192439/2dc43eaf-f335-4b27-b8a6-bbed8333226b)
