### PR TITLE
Support OGG on JS, fall back to stb

### DIFF
--- a/hxd/res/Config.hx
+++ b/hxd/res/Config.hx
@@ -91,9 +91,6 @@ class Config {
 			ignoredExtensions.set("mp3", true);
 			#end
 		default:
-			#if !stb_ogg_sound
-			ignoredExtensions.set("ogg", true);
-			#end
 		}
 		return pf;
 	}

--- a/hxd/res/Sound.hx
+++ b/hxd/res/Sound.hx
@@ -16,14 +16,8 @@ class Sound extends Resource {
 
 	public static function supportedFormat( fmt : SoundFormat ) {
 		return switch( fmt ) {
-		case Wav, Mp3:
+		case Wav, Mp3, OggVorbis:
 			return true;
-		case OggVorbis:
-			#if (hl || stb_ogg_sound)
-			return true;
-			#else
-			return false;
-			#end
 		}
 	}
 
@@ -43,11 +37,7 @@ class Sound extends Resource {
 		case 255, 'I'.code: // MP3 (or ID3)
 			data = new hxd.snd.Mp3Data(bytes);
 		case 'O'.code: // Ogg (vorbis)
-			#if (hl || stb_ogg_sound)
 			data = new hxd.snd.OggData(bytes);
-			#else
-			throw "OGG format requires -lib stb_ogg_sound (for " + entry.path+")";
-			#end
 		default:
 		}
 		if( data == null )


### PR DESCRIPTION
Allows Ogg audio files on JS with or without `stb_ogg_sound` library included. Attempts native browser handling of the file, falls back to `stb_ogg_sound` if included, and then throws a runtime error if it was not included.

If the runtime error is not preferred on Safari, we can compile-time error if an OGG is found without `stb_ogg_sound`, forcing use of the library as a fallback.

Tested on Chromebook and iOS Safari on older heaps/haxe/etc, so I'll soon do a quick check on my dev PC just to be sure.

This preserves the ability to use `stb_ogg_sound` outside of HL or JS, but I did not test that.