### PR TITLE
Pad SDL: use index in pads mapping

### DIFF
--- a/hxd/Pad.hx
+++ b/hxd/Pad.hx
@@ -509,7 +509,7 @@ class Pad {
 		if( @:privateAccess sp.ptr == null )
 			return;
 		var p = new hxd.Pad();
-		p.index = sp.id;
+		p.index = index;
 		p.d = sp;
 		pads.set( p.index, p );
 		for( axis in 0...6 )


### PR DESCRIPTION
In `onEvent()`, `e.controller` is based on `index` instead of `sp.id`, and `sp.id` is not guarantee to be the same as `index` (when index=0, sp.id=1). As we use `pads.get`, the key value should be `index` instead of `sp.id` in `initPad()`. The previous implementation can cause problem when more than 1 Pad is connected to the system: the 2nd one can cause the 1st one disconnect.