### PR TITLE
Let Window.isFocused return true when usesys.

### DIFF
--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -567,7 +567,7 @@ class Window {
 		return haxe.System.vsync = b;
 	}
 
-	function get_isFocused() : Bool return false;
+	function get_isFocused() : Bool return true;
 
 	#else
 


### PR DESCRIPTION
When setting flag -D usesys, only one single Window will be created by System.start, it should be consider having always focus.