### PR TITLE
Don't rely on deprecated annotation to declare extern fields

### DIFF
--- a/hxd/res/FileTree.hx
+++ b/hxd/res/FileTree.hx
@@ -279,8 +279,8 @@ class FileTree {
 					ret : field.t,
 					expr : { expr : EMeta({ name : ":privateAccess", params : [], pos : pos }, { expr : EReturn(field.e), pos : pos }), pos : pos },
 				}),
-				meta : [ { name:":extern", pos:pos, params:[] } ],
-				access : [AStatic, AInline, APrivate],
+				meta : [],
+				access : [AExtern, AStatic, AInline, APrivate],
 			};
 			var field : Field = {
 				name : fname,


### PR DESCRIPTION
This should get rid of the following warnings:
```
/usr/share/haxe/lib/heaps/git/hxd/Res.hx:4: characters 1-8 : Warning : (WDeprecated) `@:extern` is deprecated in favor of `extern`
```