### PR TITLE
Fix SDL pad reconnect after disconnect event error

### DIFF
--- a/hxd/Pad.hx
+++ b/hxd/Pad.hx
@@ -514,7 +514,7 @@ class Pad {
 		if( @:privateAccess sp.ptr == null )
 			return;
 		var p = new hxd.Pad();
-		p.index = index;
+		p.index = sp.id;
 		p.d = sp;
 		pads.set( p.index, p );
 		for( axis in 0...6 )
@@ -528,15 +528,8 @@ class Pad {
 		var p = pads.get( e.controller );
 		switch( e.type ){
 			case GControllerAdded:
-				if( initDone ){
-					if( p != null ){
-						pads.remove( p.index );
-						p.d.close();
-						p.connected = false;
-						p.onDisconnect();
-					}
+				if( initDone )
 					initPad(e.controller);
-				}
 			case GControllerRemoved:
 				if( p != null ){
 					pads.remove( p.index );


### PR DESCRIPTION
This commit revert #1154 #323 .
It fix error of pad event id after disconnect and reconnect (new), and allow multiple pad to be connected to the system (what was fixed by #1154).
However, it does not fix the double init in #323 (Fixed SDL double init), but I couldn't reproduce the error in a normal workflow.

The reason behind that is the e.controller is different in GControllerAdded (device id) and others events (joystick id). The joystick id is used to reference pad in pads (instead if device id), so pads.remove in GControllerAdded  will remove the wrong pad.