### PR TITLE
Cannot use bind with optional arguments

### DIFF
--- a/h3d/prim/ModelCache.hx
+++ b/h3d/prim/ModelCache.hx
@@ -50,7 +50,7 @@ class ModelCache {
 
 	public function loadModel( res : hxd.res.Model ) : h3d.scene.Object {
 		var m = loadLibraryData(res);
-		return m.lib.makeObject(loadTexture.bind(res));
+		return m.lib.makeObject(texturePath -> loadTexture(res, texturePath));
 	}
 
 	public function loadCollider( res : hxd.res.Model ) {


### PR DESCRIPTION
This used to more or less work but caused weird issues, so now `bind` can't be used with optional args
See https://github.com/HaxeFoundation/haxe/pull/11533