### PR TITLE
fix h2d.Font.resizeTo scaling

### DIFF
--- a/h2d/Font.hx
+++ b/h2d/Font.hx
@@ -279,7 +279,7 @@ class Font {
 		@param size The new font size.
 	**/
 	public function resizeTo( size : Int ) {
-		var ratio = size / initSize;
+		var ratio = size / this.size;
 		for( c in glyphs ) {
 			c.width *= ratio;
 			c.t.scaleToSize(c.t.width * ratio, c.t.height * ratio);


### PR DESCRIPTION
In https://github.com/HeapsIO/heaps/commit/e1e6e4a5f4c6c163975e427fd64d0a157b210eff `h2d.Font.resizeTo` was changed to scale by a ratio relative to initial size. This has a problem: For a font with initial size 12 `resizeTo(24)` scales it by a ratio 2. If `resizeTo(24)` is called again, we should expect no change in font size, but the ratio is again 2 because it is relative to initial size (12). The font is actually resized to 48.

This change simply reverts to previous `resizeTo` behavior. `initSize` cannot be entirely removed because it is used by `hxd.fmt.bfnt.FontParser`.

For the original issue "narrow chars becoming more narrow when resizing font", I was not able to replicate that. I tested by repeatedly scaling DefaultFont down to smaller values, and comparing the result to a font scaled only once to the final size. I noticed no difference between the two texts.

