### PR TITLE
Prevent cast int to Dyn in Shader's getParamValue

### DIFF
--- a/h3d/impl/RenderContext.hx
+++ b/h3d/impl/RenderContext.hx
@@ -247,11 +247,13 @@ class RenderContext {
 			while( p != null ) {
 				var v : Dynamic;
 				if( p.perObjectGlobal == null ) {
-					if( p.type == TFloat || p.type == TInt ) {
+					switch( p.type ) {
+					case TFloat, TInt:
 						var i = getInstance(p.instance);
 						ptr[p.pos] = i.getParamFloatValue(p.index);
 						p = p.next;
 						continue;
+					default:
 					}
 					v = getInstance(p.instance).getParamValue(p.index);
 					if( v == null ) throw "Missing param value " + curInstanceValue + "." + p.name;

--- a/h3d/impl/RenderContext.hx
+++ b/h3d/impl/RenderContext.hx
@@ -253,6 +253,12 @@ class RenderContext {
 						p = p.next;
 						continue;
 					}
+					if( p.type == TInt ) {
+						var i = getInstance(p.instance);
+						ptr[p.pos] = i.getParamIntValue(p.index);
+						p = p.next;
+						continue;
+					}
 					v = getInstance(p.instance).getParamValue(p.index);
 					if( v == null ) throw "Missing param value " + curInstanceValue + "." + p.name;
 				} else

--- a/h3d/impl/RenderContext.hx
+++ b/h3d/impl/RenderContext.hx
@@ -247,15 +247,9 @@ class RenderContext {
 			while( p != null ) {
 				var v : Dynamic;
 				if( p.perObjectGlobal == null ) {
-					if( p.type == TFloat ) {
+					if( p.type == TFloat || p.type == TInt ) {
 						var i = getInstance(p.instance);
 						ptr[p.pos] = i.getParamFloatValue(p.index);
-						p = p.next;
-						continue;
-					}
-					if( p.type == TInt ) {
-						var i = getInstance(p.instance);
-						ptr[p.pos] = i.getParamIntValue(p.index);
 						p = p.next;
 						continue;
 					}

--- a/hxsl/DynamicShader.hx
+++ b/hxsl/DynamicShader.hx
@@ -104,6 +104,10 @@ class DynamicShader extends Shader {
 		}
 	}
 
+	override function getParamIntValue(index:Int):Int {
+		return getParamValue(index);
+	}
+
 	override function getParamFloatValue(index:Int):Float {
 		var a = accesses[index];
 		if( a.kind != Float )

--- a/hxsl/DynamicShader.hx
+++ b/hxsl/DynamicShader.hx
@@ -35,7 +35,10 @@ class DynamicShader extends Shader {
 	function addVarIndex(v:hxsl.Ast.TVar, ?access : Access, ?defObj : Dynamic ) {
 		if( v.kind != Param )
 			return;
-		var isFloat = (v.type == TFloat || v.type == TInt) && access == null;
+		var isFloat = switch(v.type) {
+			case TFloat, TInt: access == null;
+			default: false;
+		}
 		var vid = isFloat ? floats.length : values.length;
 		if( access != null )
 			access = new Access(Structure, access.index, access.fields.copy());

--- a/hxsl/DynamicShader.hx
+++ b/hxsl/DynamicShader.hx
@@ -35,7 +35,7 @@ class DynamicShader extends Shader {
 	function addVarIndex(v:hxsl.Ast.TVar, ?access : Access, ?defObj : Dynamic ) {
 		if( v.kind != Param )
 			return;
-		var isFloat = v.type == TFloat && access == null;
+		var isFloat = (v.type == TFloat || v.type == TInt) && access == null;
 		var vid = isFloat ? floats.length : values.length;
 		if( access != null )
 			access = new Access(Structure, access.index, access.fields.copy());
@@ -102,10 +102,6 @@ class DynamicShader extends Shader {
 				v = Reflect.field(v, f);
 			return v;
 		}
-	}
-
-	override function getParamIntValue(index:Int):Int {
-		return getParamValue(index);
 	}
 
 	override function getParamFloatValue(index:Int):Float {

--- a/hxsl/Macros.hx
+++ b/hxsl/Macros.hx
@@ -304,22 +304,6 @@ class Macros {
 			access : [AOverride],
 		});
 		fields.push( {
-			name : "getParamIntValue",
-			pos : pos,
-			kind : FFun( {
-				ret : macro : Int,
-				args : [ { name : "index", type : macro : Int } ],
-				expr : {
-					expr : EBlock([
-						{ expr : ESwitch(macro index, [for( i in 0...tparams.length ) if( tparams[i] == TInt ) { values : [macro $v{i}], expr : macro return ${eparams[i]} }], macro {}), pos : pos },
-						macro return 0,
-					]),
-					pos : pos,
-				},
-			}),
-			access : [AOverride],
-		});
-		fields.push( {
 			name : "getParamFloatValue",
 			pos : pos,
 			kind : FFun( {
@@ -327,7 +311,7 @@ class Macros {
 				args : [ { name : "index", type : macro : Int } ],
 				expr : {
 					expr : EBlock([
-						{ expr : ESwitch(macro index, [for( i in 0...tparams.length ) if( tparams[i] == TFloat ) { values : [macro $v{i}], expr : macro return ${eparams[i]} }], macro {}), pos : pos },
+						{ expr : ESwitch(macro index, [for( i in 0...tparams.length ) if( tparams[i] == TFloat || tparams[i] == TInt ) { values : [macro $v{i}], expr : macro return ${eparams[i]} }], macro {}), pos : pos },
 						macro return 0.,
 					]),
 					pos : pos,
@@ -437,7 +421,6 @@ class Macros {
 							shader = { expr : EBlock([ { expr : ECall( { expr : EIdent("extends"), pos : pos }, [ { expr : EConst(CString(sup)), pos : pos } ]), pos : pos }, shader]), pos : pos };
 							supFields.remove("updateConstants");
 							supFields.remove("getParamValue");
-							supFields.remove("getParamIntValue");
 							supFields.remove("getParamFloatValue");
 							supFields.remove("setParamValue");
 							supFields.remove("setParamFloatValue");

--- a/hxsl/Macros.hx
+++ b/hxsl/Macros.hx
@@ -304,6 +304,22 @@ class Macros {
 			access : [AOverride],
 		});
 		fields.push( {
+			name : "getParamIntValue",
+			pos : pos,
+			kind : FFun( {
+				ret : macro : Int,
+				args : [ { name : "index", type : macro : Int } ],
+				expr : {
+					expr : EBlock([
+						{ expr : ESwitch(macro index, [for( i in 0...tparams.length ) if( tparams[i] == TInt ) { values : [macro $v{i}], expr : macro return ${eparams[i]} }], macro {}), pos : pos },
+						macro return 0,
+					]),
+					pos : pos,
+				},
+			}),
+			access : [AOverride],
+		});
+		fields.push( {
 			name : "getParamFloatValue",
 			pos : pos,
 			kind : FFun( {
@@ -421,6 +437,7 @@ class Macros {
 							shader = { expr : EBlock([ { expr : ECall( { expr : EIdent("extends"), pos : pos }, [ { expr : EConst(CString(sup)), pos : pos } ]), pos : pos }, shader]), pos : pos };
 							supFields.remove("updateConstants");
 							supFields.remove("getParamValue");
+							supFields.remove("getParamIntValue");
 							supFields.remove("getParamFloatValue");
 							supFields.remove("setParamValue");
 							supFields.remove("setParamFloatValue");

--- a/hxsl/Shader.hx
+++ b/hxsl/Shader.hx
@@ -46,16 +46,11 @@ class Shader {
 		return null;
 	}
 
-	public function getParamIntValue( index : Int ) : Int {
-		throw "assert"; // will be subclassed in sub shaders
-		return 0;
-	}
-
 	public function getParamFloatValue( index : Int ) : Float {
 		throw "assert"; // will be subclassed in sub shaders
 		return 0.;
 	}
-
+	
 	public function setParamIndexValue( index : Int, val : Dynamic ) {
 		throw "assert"; // will be subclassed in sub shaders
 	}

--- a/hxsl/Shader.hx
+++ b/hxsl/Shader.hx
@@ -46,11 +46,16 @@ class Shader {
 		return null;
 	}
 
+	public function getParamIntValue( index : Int ) : Int {
+		throw "assert"; // will be subclassed in sub shaders
+		return 0;
+	}
+
 	public function getParamFloatValue( index : Int ) : Float {
 		throw "assert"; // will be subclassed in sub shaders
 		return 0.;
 	}
-	
+
 	public function setParamIndexValue( index : Int, val : Dynamic ) {
 		throw "assert"; // will be subclassed in sub shaders
 	}


### PR DESCRIPTION
When a param is a Int, use `getParamValue` makes unnecessary cast from Int to Dynamic, which means a lots of alloc (at least in HL target). Add `getParamIntValue` (similar to `getParamFloatValue`) to fix this.

`SetParamValue` for Int seems less critical and I don't know how to manage DynamicShader, so I didn't added it.