### PR TITLE
add window move callback

### DIFF
--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -126,6 +126,9 @@ class Window {
 		return true;
 	}
 
+	public dynamic function onMove() : Void {
+	}
+
 	public dynamic function onMouseModeChange( from : MouseMode, to : MouseMode ) : Null<MouseMode> {
 		return null;
 	}
@@ -395,6 +398,9 @@ class Window {
 				event(new Event(EOut));
 			case Close:
 				return onCloseEvent();
+			case Move:
+				if( onMove != null )
+					onMove();
 			default:
 			}
 		case MouseDown if (!hxd.System.getValue(IsTouch)):


### PR DESCRIPTION
Heaps has several ways of doing window callbacks implemented, so I'm open to changing this call pattern; in this case we're using the same system as onClose (a dynamic function) but there's no need for a retval and we can't block the result so the calling pattern is simplified significantly.

The motivation for this feature is to allow multi-window apps to manage report their positions back to an underlying manager (in our case ImGui). This allows eg multi-window viewports to function.