### PR TITLE
Adding possibility to use glow filter reusing the color from the base texture.

### DIFF
--- a/h2d/domkit/BaseComponents.hx
+++ b/h2d/domkit/BaseComponents.hx
@@ -653,6 +653,8 @@ class BitmapComp extends DrawableComp implements domkit.Component.ComponentDecl<
 
 	@:p(tile) var src : h2d.Tile;
 	@:p(tilePos) var srcPos : { p : Int, ?y : Int };
+	@:p var srcFlipX : Null<Bool>;
+	@:p var srcFlipY : Null<Bool>;
 	@:p var srcPosX : Null<Int>;
 	@:p var srcPosY : Null<Int>;
 	@:p(auto) var width : Null<Float>;
@@ -678,6 +680,14 @@ class BitmapComp extends DrawableComp implements domkit.Component.ComponentDecl<
 		o.tile = setTilePosY(o.tile, y);
 	}
 
+	static function set_srcFlipX( o : h2d.Bitmap, b: Bool ) {
+		o.tile = setTileFlipX(o.tile, b);
+	}
+
+	static function set_srcFlipY( o : h2d.Bitmap, b: Bool ) {
+		o.tile = setTileFlipY(o.tile, b);
+	}
+
 	static function setTilePos( t : h2d.Tile, pos : Null<{ p : Int, ?y : Int }> ) {
 		if( t == null ) return null;
 		if( pos == null ) pos = {p:0};
@@ -701,6 +711,30 @@ class BitmapComp extends DrawableComp implements domkit.Component.ComponentDecl<
 		if( t == null ) return null;
 		t = t.clone();
 		t.setPosition(t.ix, y * t.iheight);
+		return t;
+	}
+
+	static function setTileFlipX(t : h2d.Tile, b : Bool) {
+		if (t == null) return null;
+		t = t.clone();
+		var xFlip = t.u2 < t.u;
+		if (xFlip != b) {
+			var tmp = t.u;
+			t.u = t.u2;
+			t.u2 = tmp;
+		}
+		return t;
+	}
+
+	static function setTileFlipY(t : h2d.Tile, b : Bool) {
+		if (t == null) return null;
+		t = t.clone();
+		var yFlip = t.v2 < t.v;
+		if (yFlip != b) {
+			var tmp = t.v;
+			t.v = t.v2;
+			t.v2 = tmp;
+		}
 		return t;
 	}
 

--- a/h2d/domkit/BaseComponents.hx
+++ b/h2d/domkit/BaseComponents.hx
@@ -716,9 +716,9 @@ class BitmapComp extends DrawableComp implements domkit.Component.ComponentDecl<
 
 	static function setTileFlipX(t : h2d.Tile, b : Bool) {
 		if (t == null) return null;
-		t = t.clone();
 		var xFlip = t.u2 < t.u;
 		if (xFlip != b) {
+			t = t.clone();
 			var tmp = t.u;
 			t.u = t.u2;
 			t.u2 = tmp;
@@ -728,9 +728,9 @@ class BitmapComp extends DrawableComp implements domkit.Component.ComponentDecl<
 
 	static function setTileFlipY(t : h2d.Tile, b : Bool) {
 		if (t == null) return null;
-		t = t.clone();
 		var yFlip = t.v2 < t.v;
 		if (yFlip != b) {
+			t = t.clone();
 			var tmp = t.v;
 			t.v = t.v2;
 			t.v2 = tmp;

--- a/h2d/domkit/BaseComponents.hx
+++ b/h2d/domkit/BaseComponents.hx
@@ -333,6 +333,18 @@ class CustomParser extends domkit.CssValue.ValueParser {
 			#else
 				new h2d.filter.Glow(c, a, r, g, q, b);
 			#end
+		case VCall("glow",[VIdent("none"), r, g, q]):
+			var r = parseFloat(r);
+			var g = parseFloat(g);
+			var q = parseFloat(q);
+			#if macro
+				true;
+			#else
+				var glow = new h2d.filter.Glow(0xFFFFFF, 0., r, g, q);
+				// since 'hasFixedColor' is set to false, alpha will be ignored.
+				@:privateAccess glow.pass.shader.hasFixedColor = false;
+				glow;
+			#end
 		case VCall("blur",[r]):
 			var r = parseFloat(r);
 			#if macro


### PR DESCRIPTION
How to use:
my-element {
    filter: glow(none, @radius, @gain, @quality);
}

my-other-element {
    filter: glow(@color, @alpha, @radius, @gain, @quality, @smoothColor);
}