### PR TITLE
Clone color vector in material clone function

### DIFF
--- a/h3d/mat/Material.hx
+++ b/h3d/mat/Material.hx
@@ -124,7 +124,7 @@ class Material extends BaseMaterial {
 			m.textureShader.killAlpha = textureShader.killAlpha;
 			m.textureShader.killAlphaThreshold = textureShader.killAlphaThreshold;
 		}
-		m.color = color;
+		m.color = color.clone();
 		m.blendMode = blendMode;
 		return m;
 	}


### PR DESCRIPTION
Cloning a material currently keeps a shared reference of color (Vector4). This can lead to unexpected results, when for instance calling `setColor()` on a cloned material all objects change to the same color.