### PR TITLE
Add `heaps_disable_res_completion` compilation flag

### DIFF
--- a/hxd/Res.hx
+++ b/hxd/Res.hx
@@ -1,6 +1,6 @@
 package hxd;
 
-#if !macro
+#if (!macro && !heaps_disable_res_completion)
 @:build(hxd.res.FileTree.build())
 #end
 class Res {
@@ -9,6 +9,19 @@ class Res {
 	public static function load(name:String) {
 		return loader.load(name);
 	}
+	
+	#if heaps_disable_res_completion
+	public static var loader( get, set ): hxd.res.Loader;
+	static function get_loader() {
+		var l = hxd.res.Loader.currentInstance;
+		if( l == null ) throw "Resource loader not initialized: call to hxd.Res.initXXX() required";
+		return l;
+	}
+	static function set_loader(l) {
+		return hxd.res.Loader.currentInstance = l;
+	}
+	#end
+	
 	#end
 
 	public static macro function initEmbed(?options:haxe.macro.Expr.ExprOf<hxd.res.EmbedOptions>) {


### PR DESCRIPTION
Adds a `heaps_disable_res_completion` compilation flag that will disable `@:build` macro on `hxd.Res` as well as provide generic `hxd.Res.loader` property that was generated by build macro.
It does not affect regular operation in any way and is purely an opt-in feature.

Rationale: This build macro can notably impact completion times for completion server, and paired with nightly Haxe HXB system being extremely slow for small projects (as 3 days of suffering on recent Ludum Dare shown) - being able to easily disable Res completion is direly needed. It's also useful for people who don't use the provided completion, yet still end up with extra completion lag due to it being enabled.

<detail><summary>A much more subjective rationale:</summary>
I have a lot of colorful epithets for entire HXB system introduced in HaxeFoundation/Haxe#11504 as it caused completion server to be practically useless for majority of Ludum Dare, and actively caused me problems, so unless in-memory completion cache system is back - crutches like this are mandatory to make Haxe remotely viable for small, time-constrained projects. This was my worst Ludum Dare to date for the single reason of writing code being the most painful experience I've ever had with Haxe and I was openly talking about it in a far more colorful language in Haxe discord #gamedev channel around end of LD. Pre-HXB Haxe completion times are 2 to 10 times faster than HXB depending on how long the server was alive as well as server cold-start times are abysmally slower. HXB seem to not work well with Heaps build macro-driven systems as vshaxe server timings report pretty much entire time being spent inside hxb classes that are touched by macro even if the completion location has nothing to do with macro in question.
</detail>