### PR TITLE
Fix bugs in multiline text input

### DIFF
--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -193,13 +193,24 @@ class TextInput extends Text {
 				cursorIndex++;
 		case K.HOME:
 			if( multiline ) {
-				var currentLine = getCurrentLine();
-				cursorIndex = currentLine.startIndex;
+				// In multiine, we may have word wrapped our line so keep rolling back until
+				// we find a hard return, or the beginning of the string.
+				while( cursorIndex > 0 ) {
+					var char = text.charAt(cursorIndex - 1);
+					if( char == "\n")
+						break;
+					cursorIndex--;
+				}
 			} else cursorIndex = 0;
 		case K.END:
 			if( multiline ) {
-				var currentLine = getCurrentLine();
-				cursorIndex = currentLine.startIndex + currentLine.value.length - 1;
+				do {
+					var char = text.charAt(cursorIndex);
+					if( char == "\n")
+						break;
+					cursorIndex++;
+				}
+				while( cursorIndex < text.length );
 			} else cursorIndex = text.length;
 		case K.BACKSPACE, K.DELETE if( selectionRange != null ):
 			if( !canEdit ) return;
@@ -367,15 +378,25 @@ class TextInput extends Text {
 			lines.push( { line: line, startIndex: currIndex } );
 			var prevIndex = currIndex;
 			currIndex += line.length;
-			if( cursorIndex > prevIndex && cursorIndex < currIndex )
+			if( cursorIndex >= prevIndex && cursorIndex < currIndex )
 				cursorLineIndex = currLineIndex;
 			currLineIndex++;
 		}
 		if (cursorLineIndex == -1)
 			return;
-		var destinationIndex = hxd.Math.iclamp(cursorLineIndex + yDiff, 0, lines.length - 1);
+		var destinationIndex = hxd.Math.iclamp(cursorLineIndex + yDiff, -1, lines.length);
 		if (destinationIndex == cursorLineIndex)
 			return;
+		// We're moving down from the last line, move to the end of the line
+		if( destinationIndex == lines.length) {
+			cursorIndex = text.length;
+			return;
+		}
+		// We're moving up from the first line, snap to beginning
+		if( destinationIndex == -1 ) {
+			cursorIndex = 0;
+			return;
+		}
 		var current = lines[cursorLineIndex];
 		var xOffset = 0.;
 		var prevCC: Null<Int> = null;
@@ -404,6 +425,10 @@ class TextInput extends Text {
 			prevCC = cc;
 		}
 		cursorIndex = destination.startIndex + destination.line.length;
+		// The last character in this line may be the \n, check for this and move back by one.
+		// we can't just assume this because the last line typically won't end with a newline.
+		if( destination.line.charAt(destination.line.length-1) == "\n")
+			cursorIndex--;
 	}
 
 	function setState(h:TextHistoryElement) {

--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -193,24 +193,13 @@ class TextInput extends Text {
 				cursorIndex++;
 		case K.HOME:
 			if( multiline ) {
-				// In multiine, we may have word wrapped our line so keep rolling back until
-				// we find a hard return, or the beginning of the string.
-				while( cursorIndex > 0 ) {
-					var char = text.charAt(cursorIndex - 1);
-					if( char == "\n")
-						break;
-					cursorIndex--;
-				}
+				var currentLine = getCurrentLine();
+				cursorIndex = currentLine.startIndex;
 			} else cursorIndex = 0;
 		case K.END:
 			if( multiline ) {
-				do {
-					var char = text.charAt(cursorIndex);
-					if( char == "\n")
-						break;
-					cursorIndex++;
-				}
-				while( cursorIndex < text.length );
+				var currentLine = getCurrentLine();
+				cursorIndex = currentLine.startIndex + currentLine.value.length - 1;
 			} else cursorIndex = text.length;
 		case K.BACKSPACE, K.DELETE if( selectionRange != null ):
 			if( !canEdit ) return;


### PR DESCRIPTION
This fixes some bugs in h2d.TextInput when `multiline` is set to true. These changes are isolated to `moveCursorVertically` which is gated behind `multiline`, so they should not affect the control when in the much more common single line mode.

* Fixes moving up/down a line when at the beginning of a line
* When moving up from the top line, move to the beginning of the line. Same behavior with down on the last line (moves to end of line)
* Fixes a bug when moving to a line that is hard wrapped shorter than the current position

I started making these changes due to a crash that was fixed in a recent commit, so it might be worth double checking this doesn't break other uses of this control, or collide with changes from others working on this feature. @robShiro 