### PR TITLE
🐭 Update TiledMapLayer Object definition to include height and width.

### DIFF
--- a/hxd/res/TiledMap.hx
+++ b/hxd/res/TiledMap.hx
@@ -5,7 +5,14 @@ typedef TiledMapLayer = {
 	var data : Array<Int>;
 	var name : String;
 	var opacity : Float;
-	var objects : Array<{ x: Int, y : Int, name : String, type : String }>;
+	var objects : Array<{
+		x : Float,
+		y : Float,
+		height : Float,
+		width : Float,
+		name : String,
+		type : String
+	}>;
 }
 
 typedef TiledMapData = {


### PR DESCRIPTION
In the Tiled output I got locally, I got an object similar to this, where height and width are inaccessible due to the type definition here.

```
{
                 "height":63.7613636363636,
                 "id":8,
                 "name":"",
                 "rotation":0,
                 "type":"",
                 "visible":true,
                 "width":15.6306818181818,
                 "x":32.1846590909091,
                 "y":48.1193181818182
                },
```