### PR TITLE
[hl] change for haxe hl.NativeArray for Vector

### DIFF
--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -596,7 +596,8 @@ class GlDriver extends Driver {
 		case Globals:
 			if( s.globals != null ) {
 				#if hl
-				gl.uniform4fv(s.globals, streamData(hl.Bytes.getArray(buf.globals.toData()), 0, s.shader.globalsSize * 16), 0, s.shader.globalsSize * 4);
+				var bytes = #if (haxe_ver < 5.0) hl.Bytes.getArray(buf.globals.toData()) #else buf.globals.toData().getBytes() #end;
+				gl.uniform4fv(s.globals, streamData(bytes, 0, s.shader.globalsSize * 16), 0, s.shader.globalsSize * 4);
 				#else
 				var a = buf.globals.subarray(0, s.shader.globalsSize * 4);
 				gl.uniform4fv(s.globals, a);
@@ -605,7 +606,8 @@ class GlDriver extends Driver {
 		case Params:
 			if( s.params != null ) {
 				#if hl
-				gl.uniform4fv(s.params, streamData(hl.Bytes.getArray(buf.params.toData()), 0, s.shader.paramsSize * 16), 0, s.shader.paramsSize * 4);
+				var bytes = #if (haxe_ver < 5.0) hl.Bytes.getArray(buf.params.toData()) #else buf.params.toData().getBytes() #end;
+				gl.uniform4fv(s.params, streamData(bytes, 0, s.shader.paramsSize * 16), 0, s.shader.paramsSize * 4);
 				#else
 				var a = buf.params.subarray(0, s.shader.paramsSize * 4);
 				gl.uniform4fv(s.params, a);

--- a/h3d/impl/RenderContext.hx
+++ b/h3d/impl/RenderContext.hx
@@ -178,8 +178,10 @@ class RenderContext {
 	}
 
 	inline function getPtr( data : h3d.shader.Buffers.ShaderBufferData ) {
-		#if hl
+		#if (hl && haxe_ver < 5.0)
 		return (hl.Bytes.getArray((cast data : Array<Single>)) : hl.BytesAccess<hl.F32>);
+		#elseif hl
+		return (data.toData().getBytes() : hl.BytesAccess<hl.F32>);
 		#else
 		return data;
 		#end

--- a/hxd/fmt/hmd/Library.hx
+++ b/hxd/fmt/hmd/Library.hx
@@ -257,7 +257,7 @@ class Library {
 				}
 				buf.indexes[i] = rid - 1;
 			}
-			#if neko
+			#if (neko || (hl && haxe_ver >= 5.0))
 			buf.vertexes = haxe.ds.Vector.fromArrayCopy(vertexes.getNative());
 			#else
 			buf.vertexes = haxe.ds.Vector.fromData(vertexes.getNative());


### PR DESCRIPTION
Heaps change for
- https://github.com/HaxeFoundation/haxe/pull/11568

Require also latest hashlink `hl_ver >= version("1.15.0")` for std API.
Do not merge yet, until I'm sure + sync internal haxe version first.