### PR TITLE
Add github action to automatically synchronize wiki

### DIFF
--- a/.github/workflows/sync_wiki.yml
+++ b/.github/workflows/sync_wiki.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # daily, midnight UTC
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   synchronize:

--- a/.github/workflows/sync_wiki.yml
+++ b/.github/workflows/sync_wiki.yml
@@ -1,0 +1,30 @@
+name: Synchronize Wiki
+
+on:
+  schedule:
+    # daily, midnight UTC
+    - cron: "0 0 * * *"
+
+jobs:
+  synchronize:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}.wiki
+      - name: Set git credentials
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Fetch
+        run: |
+          git remote add upstream ${{ github.server_url }}/${{ github.repository_owner }}/heaps-doc
+          git fetch upstream master
+      - name: Merge
+        run: |
+          git merge upstream/master --no-edit
+      - name: Push
+        run: |
+          git push

--- a/.github/workflows/sync_wiki.yml
+++ b/.github/workflows/sync_wiki.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}.wiki
+          fetch-depth: 0
       - name: Set git credentials
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Will run daily at midnight UTC.

There are currently merge conflicts which need to be resolved before this will work, see: https://github.com/HeapsIO/heaps-doc/pull/97