### PR TITLE
Round camera position on sync

### DIFF
--- a/h2d/Camera.hx
+++ b/h2d/Camera.hx
@@ -224,8 +224,8 @@ class Camera {
 				matC = scaleY * -sr;
 				matD = scaleY * cr;
 			}
-			absX = Math.round(-(x * matA + y * matC) + (scene.width * anchorX * viewW) + scene.width * viewX);
-			absY = Math.round(-(x * matB + y * matD) + (scene.height * anchorY * viewH) + scene.height * viewY);
+			absX = (-(x * matA + y * matC) + (scene.width * anchorX * viewW) + scene.width * viewX);
+			absY = (-(x * matB + y * matD) + (scene.height * anchorY * viewH) + scene.height * viewY);
 			invDet = 1 / (matA * matD - matB * matC);
 			posChanged = false;
 		}


### PR DESCRIPTION
I have a 2D game where the camera continually moves around, and the fact that the camera calculates its position without rounding to a sub-pixel position leads to stuttering of objects that calculate its position relative to the camera position. 
This change fixes the issue for me, but I also think it is good default behavior.