### PR TITLE
Explicitly declare the precision for integer types 

### DIFF
--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -813,8 +813,10 @@ class GlslOut {
 			// no prec
 		} else if( isVertex )
 			decl("precision highp float;");
+			decl("precision highp int;");
 		else
 			decl("precision mediump float;");
+			decl("precision mediump int;");
 
 		initVars(s);
 

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -811,13 +811,14 @@ class GlslOut {
 
 		if( isCompute ) {
 			// no prec
-		} else if( isVertex )
+		} else if( isVertex ) {
 			decl("precision highp float;");
 			decl("precision highp int;");
-		else
+		} else {
 			decl("precision mediump float;");
 			decl("precision mediump int;");
-
+		}
+	
 		initVars(s);
 
 		if( isCompute )


### PR DESCRIPTION
Since 1.10.0 default have been set to `GL2` from previous `GL`: https://github.com/HeapsIO/heaps/commit/42cd06c9e67fe43863ad5a028e2b6ab753555d44#diff-cc7e0c2966fdfe280914fd349522e9c2d19ff41f0bfb5f4f23af4d4cee7b695aR11

This seem to have introduced a change were shaders are compiled using GLSL ES 3.0 compared to previous 1.0.
Not completly sure but GLSL ES 3.00 seem to require explicit precision declarations for int at least for certain GPUs/drivers, so GPUs that strictly follow the standard (a lot of Adreno GPUs) will not compile. Hoping that explicitly declaring fixes the problem.