### PR TITLE
Fix incorrect scissor box in h2d.Scene.captureBitmap

### DIFF
--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -905,11 +905,12 @@ class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.I
 			var tex = new h3d.mat.Texture(width, height, [Target]);
 			target = new Tile(tex,0, 0, width, height);
 		}
+		
+		var tex = target.getTexture();
 		engine.begin();
+		engine.pushTarget(tex);
 		engine.setRenderZone(Std.int(target.x), Std.int(target.y), hxd.Math.ceil(target.width), hxd.Math.ceil(target.height));
 
-		var tex = target.getTexture();
-		engine.pushTarget(tex);
 		var ow = width, oh = height, ova = viewportA, ovd = viewportD, ovx = viewportX, ovy = viewportY;
 		width = tex.width;
 		height = tex.height;


### PR DESCRIPTION
Currently, there is an issue with the OpenGL driver when using `h2d.Scene.captureBitmap`. When it sets the scissor bounds to the viewport bounds, `GlDriver.curTexture` incorrectly refers to the current texture rather than the texture being rendered into, causing the scissor box to potentially use an incorrect position. I will note that the DirectX driver has no problem here because it doesn't need to alter the scissor box if it's rendering to a texture, which the OpenGL driver needs to do.

I have fixed this by simply reordering some function calls in `h2d.Scene.captureBitmap` to ensure the correct framebuffer will be set when `setRenderZone` is called.