### PR TITLE
Respect hscriptPos flag for shader live reload

### DIFF
--- a/hxsl/SharedShader.hx
+++ b/hxsl/SharedShader.hx
@@ -346,10 +346,10 @@ class SharedShader {
 		#else
 		var parser = new hscript.Parser();
 		var m = try parser.parseModule(text,fs.path) catch( e : hscript.Expr.Error ) {
-			#if hscriptPos
-			Sys.println(e.toString());
-			#else
+			#if sys
 			Sys.println(hscript.Printer.errorToString(e));
+			#else
+			trace(hscript.Printer.errorToString(e));
 			#end
 			return null;
 		}

--- a/hxsl/SharedShader.hx
+++ b/hxsl/SharedShader.hx
@@ -346,7 +346,11 @@ class SharedShader {
 		#else
 		var parser = new hscript.Parser();
 		var m = try parser.parseModule(text,fs.path) catch( e : hscript.Expr.Error ) {
+			#if hscriptPos
 			Sys.println(e.toString());
+			#else
+			Sys.println(hscript.Printer.errorToString(e));
+			#end
 			return null;
 		}
 		var clName = name.split(".").pop();


### PR DESCRIPTION
Live reload did not respect lack of `hscriptPos` flag, causing compilation error, as it tried to call a function on a type that didn't have it.

fix #1261