### PR TITLE
Fix HLSL texel fetch

### DIFF
--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -458,7 +458,7 @@ class HlslOut {
 		case TCall({ e : TGlobal(g = (Texel)) }, args):
 			addValue(args[0], tabs);
 			add(".Load(");
-			switch( args[1].t ) {
+			switch( args[0].t ) {
 			case TSampler(dim,arr):
 				var size = Tools.getDimSize(dim, arr) + 1;
 				add("int"+size+"(");


### PR DESCRIPTION
Wrong argument was used to determine required vector size on HLSL generator for texel fetch operation. 
Fixes #1255