### PR TITLE
Implement HXSL Syntax.code support

### DIFF
--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -180,7 +180,7 @@ enum TExprDef {
 	TWhile( e : TExpr, loop : TExpr, normalWhile : Bool );
 	TMeta( m : String, args : Array<Const>, e : TExpr );
 	TField( e : TExpr, name : String );
-	TSyntax(target: SyntaxTarget, code : String, args : Array<SyntaxArg> );
+	TSyntax(target : String, code : String, args : Array<SyntaxArg> ); // target = "code" should be treated as "insert regardless of target"
 }
 
 typedef TVar = {
@@ -323,13 +323,6 @@ enum SyntaxArgAccess {
 typedef SyntaxArg = {
 	e: TExpr,
 	access: SyntaxArgAccess,
-}
-
-enum SyntaxTarget {
-	/** Applies to any target language **/
-	Code;
-	Glsl;
-	Hlsl;
 }
 
 enum Component {

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -551,19 +551,12 @@ class Checker {
 				// not closure support
 				error("Global function must be called immediately", e.pos);
 			}
-		case ECall({ expr: EField({ expr: EIdent("Syntax") }, syntaxStr) }, args):
-			var target: Ast.SyntaxTarget = try {
-				Ast.SyntaxTarget.createByName(syntaxStr.charAt(0).toUpperCase() + syntaxStr.substr(1));
-			} catch (_) {
-				error("Unsupported Syntax target: " + syntaxStr, e.pos);
-			}
-			if ( target == null )
-				error("Unsupported Syntax target: " + syntaxStr, e.pos);
+		case ECall({ expr: EField({ expr: EIdent("Syntax") }, target) }, args):
 			if ( args.length == 0 )
-				error("Syntax." + syntaxStr + " should have a string as first argument", e.pos);
+				error("Syntax." + target + " should have a string as first argument", e.pos);
 			var code = switch ( args[0].expr ) {
 				case EConst(CString(code)): code;
-				default: error("Syntax." + syntaxStr + " should have a string as first argument", args[0].pos);
+				default: error("Syntax." + target + " should have a string as first argument", args[0].pos);
 			}
 			var sargs: Array<Ast.SyntaxArg> = [];
 			for ( i in 1...args.length ) {
@@ -578,7 +571,7 @@ class Checker {
 							}
 						});
 					default:
-						error("Syntax.code arguments should have an access meta of @r, @w or @rw", arg.pos);
+						error("Syntax." + target + " arguments should have an access meta of @r, @w or @rw", arg.pos);
 				}
 			}
 			return { e: TSyntax(target, code, sargs), t: TVoid, p: e.pos };

--- a/hxsl/Checker.hx
+++ b/hxsl/Checker.hx
@@ -551,6 +551,37 @@ class Checker {
 				// not closure support
 				error("Global function must be called immediately", e.pos);
 			}
+		case ECall({ expr: EField({ expr: EIdent("Syntax") }, syntaxStr) }, args):
+			var target: Ast.SyntaxTarget = try {
+				Ast.SyntaxTarget.createByName(syntaxStr.charAt(0).toUpperCase() + syntaxStr.substr(1));
+			} catch (_) {
+				error("Unsupported Syntax target: " + syntaxStr, e.pos);
+			}
+			if ( target == null )
+				error("Unsupported Syntax target: " + syntaxStr, e.pos);
+			if ( args.length == 0 )
+				error("Syntax." + syntaxStr + " should have a string as first argument", e.pos);
+			var code = switch ( args[0].expr ) {
+				case EConst(CString(code)): code;
+				default: error("Syntax." + syntaxStr + " should have a string as first argument", args[0].pos);
+			}
+			var sargs: Array<Ast.SyntaxArg> = [];
+			for ( i in 1...args.length ) {
+				var arg = args[i];
+				switch ( arg.expr ) {
+					case EMeta(flags = ("rw"|"r"|"w"), _, flaggedArg):
+						sargs.push({ e : typeExpr(flaggedArg, Value), access : switch( flags ) {
+								case "r": Read;
+								case "w": Write;
+								case "rw": ReadWrite;
+								default: throw "assert";
+							}
+						});
+					default:
+						error("Syntax.code arguments should have an access meta of @r, @w or @rw", arg.pos);
+				}
+			}
+			return { e: TSyntax(target, code, sargs), t: TVoid, p: e.pos };
 		case ECall(e1, args):
 			function makeCall(e1) {
 				return switch( e1.t ) {

--- a/hxsl/Dce.hx
+++ b/hxsl/Dce.hx
@@ -266,6 +266,29 @@ class Dce {
 			check(val, writeTo, isAffected);
 			writeTo.pop();
 			isAffected.append(v,15);
+		case TSyntax(_, _, args):
+			for ( arg in args ) {
+				if ( arg.access != Read ) {
+					var tvars : Array<VarDeps> = [];
+					function findTVars( e : TExpr ) {
+						switch ( e.e ) {
+							case TVar(v): tvars.push(get(v));
+							default: e.iter(findTVars);
+						}
+					}
+					findTVars(arg.e);
+					for ( v in tvars ) {
+						writeTo.push(v, 15);
+						for ( arg2 in args ) {
+							if ( arg2.access != Write ) check(arg2.e, writeTo, isAffected);
+						}
+						writeTo.pop();
+						isAffected.append(v, 15);
+					}
+				} else {
+					check(arg.e, writeTo, isAffected);
+				}
+			}
 		default:
 			e.iter(check.bind(_, writeTo, isAffected));
 		}

--- a/hxsl/Eval.hx
+++ b/hxsl/Eval.hx
@@ -564,6 +564,8 @@ class Eval {
 			TMeta(name, args, e2);
 		case TField(e, name):
 			TField(evalExpr(e), name);
+		case TSyntax(target, code, args):
+			TSyntax(target, code, [for ( arg in args ) ({ e : evalExpr(arg.e), access : arg.access })]);
 		};
 		return { e : d, t : t, p : e.p }
 	}

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -663,7 +663,7 @@ class GlslOut {
 			addExpr(val, tabs);
 			add(".");
 			add(name);
-		case TSyntax(Code | Glsl, code, args):
+		case TSyntax("code" | "glsl", code, args):
 			var pos = 0;
 			var argRegex = ~/{(\d+)}/g;
 			while ( argRegex.matchSub(code, pos) ) {

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -663,6 +663,22 @@ class GlslOut {
 			addExpr(val, tabs);
 			add(".");
 			add(name);
+		case TSyntax(Code | Glsl, code, args):
+			var pos = 0;
+			var argRegex = ~/{(\d+)}/g;
+			while ( argRegex.matchSub(code, pos) ) {
+				var matchPos = argRegex.matchedPos();
+				add(code.substring(pos, matchPos.pos));
+				var index = Std.parseInt(argRegex.matched(1));
+				// if (index >= args.length) throw "Attempting to use substitution index of " + index + ", which is out of bounds of argument list";
+				if ( index < args.length )
+					addValue(args[index].e, tabs);
+
+				pos = matchPos.pos + matchPos.len;
+			}
+			add(code.substr(pos));
+		case TSyntax(_, _, _):
+			// Do nothing: Code for other language
 		}
 	}
 

--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -709,7 +709,7 @@ class HlslOut {
 			addValue(e, tabs);
 			add(".");
 			add(f);
-		case TSyntax(Code | Hlsl, code, args):
+		case TSyntax("code" | "hlsl", code, args):
 			var pos = 0;
 			var argRegex = ~/{(\d+)}/g;
 			while ( argRegex.matchSub(code, pos) ) {

--- a/hxsl/HlslOut.hx
+++ b/hxsl/HlslOut.hx
@@ -709,6 +709,22 @@ class HlslOut {
 			addValue(e, tabs);
 			add(".");
 			add(f);
+		case TSyntax(Code | Hlsl, code, args):
+			var pos = 0;
+			var argRegex = ~/{(\d+)}/g;
+			while ( argRegex.matchSub(code, pos) ) {
+				var matchPos = argRegex.matchedPos();
+				add(code.substring(pos, matchPos.pos));
+				var index = Std.parseInt(argRegex.matched(1));
+				// if (index >= args.length) throw "Attempting to use substitution index of " + index + ", which is out of bounds of argument list";
+				if ( index < args.length )
+					addValue(args[index].e, tabs);
+
+				pos = matchPos.pos + matchPos.len;
+			}
+			add(code.substr(pos));
+		case TSyntax(_, _, _):
+			// Do nothing: Code for other language
 		}
 	}
 

--- a/hxsl/Printer.hx
+++ b/hxsl/Printer.hx
@@ -305,7 +305,7 @@ class Printer {
 			add(name);
 		case TSyntax(target, code, args):
 			add("Syntax.");
-			add(target.getName().toLowerCase());
+			add(target);
 			add("(");
 			addConst(CString(code));
 			for ( arg in args ) {

--- a/hxsl/Printer.hx
+++ b/hxsl/Printer.hx
@@ -303,6 +303,20 @@ class Printer {
 			addExpr(e, tabs);
 			add(".");
 			add(name);
+		case TSyntax(target, code, args):
+			add("Syntax.");
+			add(target.getName().toLowerCase());
+			add("(");
+			addConst(CString(code));
+			for ( arg in args ) {
+				switch ( arg.access ) {
+					case Read: add(", @r ");
+					case Write: add(", @w ");
+					case ReadWrite: add(", @rw ");
+				}
+				addExpr(arg.e, tabs);
+			}
+			add(")");
 		}
 
 	}

--- a/hxsl/Serializer.hx
+++ b/hxsl/Serializer.hx
@@ -324,7 +324,7 @@ class Serializer {
 			writeExpr(e);
 			writeString(name);
 		case TSyntax(target, code, args):
-			out.addByte(target.getIndex());
+			writeString(target);
 			writeString(code);
 			writeArr(args, (arg) -> {
 				writeExpr(arg.e);
@@ -398,7 +398,7 @@ class Serializer {
 		case 19: TWhile(readExpr(), readExpr(), input.readByte() != 0);
 		case 20: TMeta(readString(), readArr(readConst), readExpr());
 		case 21: TField(readExpr(), readString());
-		case 22: TSyntax(Ast.SyntaxTarget.createByIndex(input.readByte()), readString(), readArr(() -> {
+		case 22: TSyntax(readString(), readString(), readArr(() -> {
 			return {
 				e: readExpr(),
 				access: Ast.SyntaxArgAccess.createByIndex(input.readByte()),

--- a/hxsl/Serializer.hx
+++ b/hxsl/Serializer.hx
@@ -323,6 +323,13 @@ class Serializer {
 		case TField(e,name):
 			writeExpr(e);
 			writeString(name);
+		case TSyntax(target, code, args):
+			out.addByte(target.getIndex());
+			writeString(code);
+			writeArr(args, (arg) -> {
+				writeExpr(arg.e);
+				out.addByte(arg.access.getIndex());
+			});
 		}
 		writeType(e.t);
 		// no position
@@ -391,6 +398,14 @@ class Serializer {
 		case 19: TWhile(readExpr(), readExpr(), input.readByte() != 0);
 		case 20: TMeta(readString(), readArr(readConst), readExpr());
 		case 21: TField(readExpr(), readString());
+		case 22: TSyntax(Ast.SyntaxTarget.createByIndex(input.readByte()), readString(), readArr(() -> {
+			return {
+				e: readExpr(),
+				access: Ast.SyntaxArgAccess.createByIndex(input.readByte()),
+				read: false,
+				write: false,
+			};
+		}));
 		default: throw "assert";
 		}
 		return {

--- a/hxsl/Splitter.hx
+++ b/hxsl/Splitter.hx
@@ -320,6 +320,30 @@ class Splitter {
 			inf.local = true;
 			inf.write++;
 			checkExpr(loop);
+		case TSyntax(_, _, args):
+			var arg : Ast.SyntaxArg = null;
+			function checkSyntaxExpr( e : Ast.TExpr) {
+				switch ( e.e ) {
+					case TVar(v):
+						var inf = get(v);
+						// inf.read is decremented in order to keep accurate count of reads
+						// as it will be incremented by checkExpr afterwards
+						switch ( arg.access ) {
+							case Read: inf.read--;
+							case Write: inf.write++;
+							case ReadWrite:
+								inf.read--;
+								inf.write++;
+						}
+					default:
+						e.iter(checkSyntaxExpr);
+				}
+			}
+			for (i in 0...args.length) {
+				arg = args[i];
+				checkSyntaxExpr(arg.e);
+				checkExpr(arg.e);
+			}
 		default:
 			e.iter(checkExpr);
 		}


### PR DESCRIPTION
The proverbial footgun. Introduces `Syntax.code` to HXSL.

Rationale is that feature being primarily for rare cases where HXSL doesn't offer some very specific language feature (from recent examples - no access to GLSL `GL_FragDepth`), but user needs access to it. Being able to inject raw language code is much less work than having to somehow implement those features. Additionally it gives partial resolution to all those people in discord asking if they can just use raw GLSL/HLSL for their shaders.
Personal reasoning: I prefer giving the user options to shoot themselves in the foot if they so wish. If they want to do some weird stuff with shaders that HXSL can't do out of the box and likely will break - let them, it's their feet, not mine.

The implementation is somewhat volatile, but there's not much can be done about it, given how HXSL compilation process goes.

## Syntax
Feature reserves the `ECall(EField("Syntax", target))` expression access as attempt to inject raw code. Target can be `code`, `hlsl` or `glsl` respectively. The `code` target is language-independent variant and applied in both GLSL and HLSL outputs.
Additionally, due to how HXSL compilation process operates every argument have to be denoted with a meta of `@r`, `@w` or `@rw`, to specify how that variable going to be used.

Usage is similar to other `Syntax.code` implementations:
`Syntax.code("{0} = someOp({1})", @w pixelColor, @r textureColor)`

## Implementation details
* Introduces new `TSyntax` typed expression.
* Syntax calls are always `TVoid`, and thus cannot be used to obtain some data directly. It may be possible to implement, however.
* `TSyntax` is considered to always have side effects.
* Checker: Converts `Syntax.` calls into `TSyntax` and verifies that arguments are valid (first arg should be const String, rest is optional arguments with access meta)
* Linker: Introduced `hasSyntax` flag to `ShaderInfos`, which is set when `TSyntax` is used. Processes read/write flags. When Syntax is used, shader is treated same as when `isCompute` or `hasDiscard` are set.
* DCE: Will link referenced vars based on read/write flags. All write variables are considered to depend on all read variables.
* Splitter: Processes read/write flags.
* Printer/Serializer: Properly supported

### Notes
* It's currently possible to do `Syntax.code("{0}", @rw (var1 + var2))`, which would mark both var1/2 as write. I'm not sure if we should allow multiple `TVar` references per argument when write flag is set.
* Implementation could be simplified with removing closures if we add a check of "inSyntaxArg" when processing expressions in linker/dce/splitter. Current version is aimed to impact regular compilation step as little as possible, as it's expected that Syntax will be very rarely used.
* Syntax.code is not allowed at top-level, only inside methods, meaning it's impossible to manually add custom top-level code.
* Regardless of compile target all Syntax calls are processed. Thus `Syntax.hlsl` would still impact compilation even for GLSL. This is due to compiler not exactly being aware of which language it targets until the very last step.
* Syntax currently does not verify if code attempts to slot in argument that is outside of argument list.