### PR TITLE
Ignore shader dump folder in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin
 .vscode
 /tools/meshtools/out
 *.exe
+/shaders


### PR DESCRIPTION
Adds `/shaders` directory to .gitignore, so when `shader_debug_dump` is set while working on library itself it won't show up in git. (My setup workspace root for issues/features is in Heaps directory)