### PR TITLE
Convert: add localParams for collide per mat in hmd

### DIFF
--- a/h3d/mat/PbrMaterial.hx
+++ b/h3d/mat/PbrMaterial.hx
@@ -95,6 +95,7 @@ typedef PbrProps = {
 	@:optional var drawOrder : String;
 	@:optional var depthPrepass : Bool;
 	@:optional var flipBackFaceNormal : Bool;
+	@:optional var ignoreCollide : Bool;
 }
 
 class PbrMaterial extends Material {
@@ -437,7 +438,7 @@ class PbrMaterial extends Material {
 		if ( props.flipBackFaceNormal && sh == null )
 			mainPass.addShader(new h3d.shader.FlipBackFaceNormal());
 		else if ( !props.flipBackFaceNormal && sh != null )
-			mainPass.removeShader(sh); 
+			mainPass.removeShader(sh);
 	}
 
 	function setColorMask() {
@@ -625,6 +626,7 @@ class PbrMaterial extends Material {
 				</dd>
 				<dt>Depth prepass</dt><dd><input type="checkbox" field="depthPrepass"/></dd>
 				<dt>Flip back face normal</dt><dd><input type="checkbox" field="flipBackFaceNormal"/></dd>
+				<dt>Ignore collide</dt><dd><input type="checkbox" field="ignoreCollide"/></dd>
 			</dl>
 		');
 	}

--- a/hxd/fmt/fbx/HMDOut.hx
+++ b/hxd/fmt/fbx/HMDOut.hx
@@ -24,6 +24,8 @@ class HMDOut extends BaseLibrary {
 	public var generateNormals = false;
 	public var generateTangents = false;
 	public var generateCollides : CollideParams;
+	public var ignoreCollides : Array<String>;
+	var ignoreCollidesCache : Map<Int,Bool> = [];
 	public var lowPrecConfig : Map<String,Precision>;
 	public var lodsDecimation : Array<Float>;
 
@@ -845,9 +847,18 @@ class HMDOut extends BaseLibrary {
 			}
 			var triangleCount = 0;
 			for ( i in 0...Std.int(index.length / 3) ) {
-				var mat = mats == null ? 0 : mats[i];
+				var mat = (mats == null || i >= mats.length) ? 0 : mats[i];
 				if ( mat >= d.materials.length )
 					continue;
+				if( ignoreCollides != null ) {
+					var b = ignoreCollidesCache.get(mat);
+					if( b == null ) {
+						b = ignoreCollides.contains(d.materials[mat].name);
+						ignoreCollidesCache.set(mat, b);
+					}
+					if( b == true )
+						continue;
+				}
 				cb(unpackIndex(index[3*i]));
 				cb(unpackIndex(index[3*i+1]));
 				cb(unpackIndex(index[3*i+2]));


### PR DESCRIPTION
Add `hasLocalParams` and `computeLocalParams` in Convert, which allows specify additional parameters than the params in `props.json`.

In this specific use case, it allows configuring, by material, option `ignoreCollide` (only if the node `collide` is present in fbx->hmd conversion rule in `props.json`).
Related commit : https://github.com/HeapsIO/heaps/commit/07cf21e892533eaa0baece22eb390aeeea664e90