### PR TITLE
Avoid conditionals in SDF shader

### DIFF
--- a/h3d/shader/SignedDistanceField.hx
+++ b/h3d/shader/SignedDistanceField.hx
@@ -29,13 +29,15 @@ class SignedDistanceField extends hxsl.Shader {
 
 		function fragment() {
 			var textureSample : Vec4 = textureColor;
-			var distance : Float;
-
-			distance = if (channel == 0) textureSample.r;
-				else if (channel == 1) textureSample.g;
-				else if (channel == 2) textureSample.b;
-				else if (channel == 3) textureSample.a;
-				else median(textureSample.r, textureSample.g, textureSample.b);
+			var distances = [
+				textureSample.r,
+				textureSample.g,
+				textureSample.b,
+				textureSample.a,
+				median(textureSample.r, textureSample.g, textureSample.b),
+			];
+			var ch = int(clamp(float(channel),0,4));
+			var distance = distances[ch];
 
 			var smoothVal = autoSmoothing ? abs(fwidth(distance) * 0.5) : smoothing;
 			textureColor = vec4(1.0, 1.0, 1.0, smoothstep(alphaCutoff - smoothVal, alphaCutoff + smoothVal, distance));


### PR DESCRIPTION
Have been looking in to an issue with WebGL context sometimes crashing on old Adreno GPUs when compiling shaders. 
Managed to resolve it by disabling mipmapping that was unnecessarily enabled on our text, but while investigating the issue I found that removing conditionals from the SignedDistanceField shader significantly reduced the crash frequency.
