### PR TITLE
[hl/Win] Prevent SDL stay in relative mouse mode on exception

### DIFF
--- a/hxd/System.hl.hx
+++ b/hxd/System.hl.hx
@@ -124,7 +124,7 @@ class System {
 		timeoutTick();
 		haxe.Timer.delay(runMainLoop, 0);
 	}
-	
+
 	static function isAlive() {
 		#if usesys
 		return true;
@@ -204,17 +204,28 @@ class System {
 		if( dismissErrors )
 			return;
 
+		#if (hlsdl && !multidriver)
+		// New UI window does not force SDL leave relative mouse mode, do it manually
+		var prevMouseMode = hxd.Window.getInstance().mouseMode;
+		hxd.Window.getInstance().mouseMode = Absolute;
+		#end
 		var f = new hl.UI.WinLog("Uncaught Exception", 500, 400);
 		f.setTextContent(err+"\n"+stack);
 		var but = new hl.UI.Button(f, "Continue");
 		but.onClick = function() {
 			hl.UI.stopLoop();
+			#if (hlsdl && !multidriver)
+			hxd.Window.getInstance().mouseMode = prevMouseMode;
+			#end
 		};
 
 		var but = new hl.UI.Button(f, "Dismiss all");
 		but.onClick = function() {
 			dismissErrors = true;
 			hl.UI.stopLoop();
+			#if (hlsdl && !multidriver)
+			hxd.Window.getInstance().mouseMode = prevMouseMode;
+			#end
 		};
 
 		var but = new hl.UI.Button(f, "Exit");


### PR DESCRIPTION
With SDL + mouse relative mode, when an exception is thrown in `reportError`, the SDL window keep the mouse in relative mode (mouse stay at the center of the window), which prevent user clicking freely on "Continue" in the pop-up `hl.UI.Window`, and user can only leave the situation with Alt-Tab.

Additionally:
- Forcing `hl.UI.Window` take focus (`SetFocus`) in native C code does not seems to have an impact, probably because it's not considerer as a standalone window.
- I cannot repro with DirectX

This PR manually set SDL in Absolute mouse mode before pop-up window, and restore it afterward.