### PR TITLE
Fix preceding char getting cut off during word wrap and add option to disable word wrapping

### DIFF
--- a/h2d/Text.hx
+++ b/h2d/Text.hx
@@ -385,7 +385,7 @@ class Text extends Drawable {
 			else if( (x + esize + letterSpacing) - wLastSep > maxWidth && wordWrap ) {
 				newline = true;
 				lines.push(text.substr(restPos, i - restPos));
-				restPos = i + 1;
+				restPos = i;
 			}
 			if( e != null && cc != '\n'.code )
 				x += esize + letterSpacing;
@@ -447,7 +447,7 @@ class Text extends Drawable {
 			var cc = StringTools.fastCodeAt(t, i);
 			var e = font.getChar(cc);
 			var offs = e.getKerningOffset(prevChar);
-			var esize = e.width + offs;
+			var esize = e.t.dx + e.width + offs;
 			// if the next word goes past the max width, change it into a newline
 
 			if( cc == '\n'.code ) {

--- a/h2d/Text.hx
+++ b/h2d/Text.hx
@@ -382,10 +382,11 @@ class Text extends Drawable {
 				}
 				else wLastSep = size;
 			}
-			else if( (x + esize + letterSpacing) - wLastSep > maxWidth && wordWrap ) {
+			else if( (x + esize + letterSpacing) - wLastSep > (maxWidth-esize) && wordWrap ) {
 				newline = true;
 				lines.push(text.substr(restPos, i - restPos));
 				restPos = i;
+				x -= esize + letterSpacing;
 			}
 			if( e != null && cc != '\n'.code )
 				x += esize + letterSpacing;
@@ -447,7 +448,7 @@ class Text extends Drawable {
 			var cc = StringTools.fastCodeAt(t, i);
 			var e = font.getChar(cc);
 			var offs = e.getKerningOffset(prevChar);
-			var esize = e.t.dx + e.width + offs;
+			var esize = e.width + offs;
 			// if the next word goes past the max width, change it into a newline
 
 			if( cc == '\n'.code ) {

--- a/h2d/Text.hx
+++ b/h2d/Text.hx
@@ -111,6 +111,10 @@ class Text extends Drawable {
 		Allow line break.
 	**/
 	public var lineBreak(default,set) : Bool = true;
+	/**
+		Allow word wrapping.
+	**/
+	public var wordWrap(default,set) : Bool = true;
 
 	var glyphs : TileGroup;
 	var needsRebuild : Bool;
@@ -196,6 +200,13 @@ class Text extends Drawable {
 	function set_lineBreak(b) {
 		if( lineBreak == b ) return b;
 		lineBreak = b;
+		rebuild();
+		return b;
+	}
+
+	function set_wordWrap(b) {
+		if( wordWrap == b ) return b;
+		wordWrap = b;
 		rebuild();
 		return b;
 	}
@@ -371,7 +382,7 @@ class Text extends Drawable {
 				}
 				else wLastSep = size;
 			}
-			else if( (x + esize + letterSpacing) - wLastSep > maxWidth ) {
+			else if( (x + esize + letterSpacing) - wLastSep > maxWidth && wordWrap ) {
 				newline = true;
 				lines.push(text.substr(restPos, i - restPos));
 				restPos = i + 1;


### PR DESCRIPTION
This will solve the issue where a word gets broken into a new line and the previous char on the new line gets skipped. There is also now the option to disable mid word splitting.