### PR TITLE
Add maxPixelRatio to Window.js to allow for limiting of used device pixel ratio

### DIFF
--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -75,6 +75,11 @@ class Window {
 	**/
 	public var useScreenPixels : Bool = js.Browser.supported;
 	/**
+		Sets the maximum pixel ratio that will be used (only applicable with useScreenPixels enabled).
+		(default : Browser.window.devicePixelRatio)
+	**/
+	public var maxPixelRatio : Float = js.Browser.window.devicePixelRatio;
+	/**
 		When enabled, the user click event on the canvas that would trigger mouse capture to be enabled would be discarded.
 		(default : true)
 	**/
@@ -306,7 +311,7 @@ class Window {
 	}
 
 	function getPixelRatio() {
-		return useScreenPixels ? js.Browser.window.devicePixelRatio : 1;
+		return useScreenPixels ? Math.min(js.Browser.window.devicePixelRatio, maxPixelRatio) : 1;
 	}
 
 	function get_width() {


### PR DESCRIPTION
This PR adds a new variable, maxPixelRatio, that acts as an upper limit for the device pixel ratio (devicePixelRatio) used when sizing the WebGL canvas.

On high-DPI devices (such as Retina displays on iOS or high-density Android screens), browsers report a devicePixelRatio that can often be 2–3 or higher. Using this high pixel ratio directly for the WebGL canvas significantly increases GPU memory usage. This is particularly problematic on iOS, which imposes strict memory limits per browser tab, which can lead to frequent tab reloads and instability.