### PR TITLE
fix: Blur-based filters under-extend on small radius

### DIFF
--- a/h2d/filter/Blur.hx
+++ b/h2d/filter/Blur.hx
@@ -49,7 +49,7 @@ class Blur extends Filter {
 	inline function set_linear(v) return pass.linear = v;
 
 	override function sync( ctx : RenderContext, s : Object ) {
-		boundsExtend = radius * 2;
+		boundsExtend = Math.ceil(radius) * 2;
 	}
 
 	override function draw( ctx : RenderContext, t : h2d.Tile ) {


### PR DESCRIPTION
When blur-based filters (such as outline) have a small radius (<1) - it causes the outline to be cut off due to undersized texture.
Ceiling `boundsExtend` fixes that issue. 
UPD: Changed to ceiling `radius` when assigning `boundsExtend` so it would extend uniformly regardless of radius value.