### PR TITLE
FileConvert: use hashed paramsStr if too long

### DIFF
--- a/hxd/fs/FileConverter.hx
+++ b/hxd/fs/FileConverter.hx
@@ -243,8 +243,12 @@ class FileConverter {
 			outFile += e.path.substr(0, -(ext.length + 1));
 		else
 			outFile += e.path;
-		if( cmd.paramsStr != null )
-			outFile += "."+cmd.paramsStr;
+		if( cmd.paramsStr != null ) {
+			var paramsStr = cmd.paramsStr;
+			if( paramsStr.length > 40 )
+				paramsStr = haxe.crypto.Sha1.make(haxe.io.Bytes.ofString(paramsStr)).toHex();
+			outFile += "." + paramsStr;
+		}
 		var conv = null;
 		for( c in cmd.conv )
 			if( c.sourceExts == null || c.sourceExts.indexOf(ext) >= 0 ) {


### PR DESCRIPTION
When we have many params for a convert (e.g. lowp, lodsDecimation, collide for fbx2hmd), it can result in an output path > 256 characters limits on Windows.
Reduce this by sha1 hash's hex the params if paramsStr is longer than the hash.

I agree that this is less readable for users, but we're very likely reaching this limit soon.