### PR TITLE
Fix Switch build failed 

### DIFF
--- a/hxd/fs/SourceLoader.hx
+++ b/hxd/fs/SourceLoader.hx
@@ -3,7 +3,7 @@ package hxd.fs;
 class SourceLoader {
 
 	static var RELOAD_LFS : Array<hxd.fs.FileSystem> = [];
-	#if sys
+	#if (sys && !usesys)
 	public static function addLivePath( path : String ) {
 		RELOAD_LFS.push(new hxd.fs.LocalFileSystem(path,""));
 	}


### PR DESCRIPTION
On Console (Test on Switch), call of sys.io.Process trigger that error : `error : undefined symbol: hl_process_stdin_close`
It's fine because we don't need it on console. But in the SourceLoader.hx there is a call of it keeped in console. 
I place a test on preprocessor usesys toi avoid that. 